### PR TITLE
add saucy for ceres import

### DIFF
--- a/config/ceres.upstream.yaml
+++ b/config/ceres.upstream.yaml
@@ -1,6 +1,6 @@
 name: ceres
 method: http://ppa.launchpad.net/mikeferguson/ceres-solver/ubuntu
-suites: [trusty, utopic, vivid]
+suites: [saucy, trusty, utopic, vivid]
 component: main
 architectures: [i386, amd64, source]
 filter_formula: Package (== ceres-solver ) | Package (% libceres ) | Package (% libceres-dev )


### PR DESCRIPTION
This was not originally building correctly when the import was added, but it does now exist in the PPA (and has for some time). I just finally released the first thing that depends on libceres-dev into Indigo, and noticed that it failed to build on Saucy because of this.