### PR TITLE
Add importer for sixad 1.6+ from mikepurvis.

### DIFF
--- a/config/qtsixa.upstream.yaml
+++ b/config/qtsixa.upstream.yaml
@@ -1,8 +1,6 @@
 name: qtsixa
 method: http://ppa.launchpad.net/falk-t-j/qtsixa/ubuntu
-# For now only import saucy, trusty. PQR have patched versions for openni compatibility
-# suites: [lucid, maverick, natty, oneiric, precise, quantal, raring, saucy, trusty]
-suites: [saucy, trusty]
+suites: [saucy]
 component: main
 architectures: [i386, amd64, source]
 filter_formula: Package (== qtsixa ) | Package (== sixad)

--- a/config/sixad.upstream.yaml
+++ b/config/sixad.upstream.yaml
@@ -1,0 +1,6 @@
+name: sixad
+method: http://ppa.launchpad.net/mikepurvis/sixaxis/ubuntu
+suites: [trusty, vivid]
+component: main
+architectures: [i386, amd64, source]
+filter_formula: Package (== sixad)


### PR DESCRIPTION
Saucy is EOL, so Launchpad won't let me push a release for that. As such, I've left it pulling qtsixa, and added sixad 1.6+ as pulling for trusty and vivid (utopic is also EOL).

More rationale here: https://github.com/ros/rosdistro/pull/9297#issuecomment-138983648

@mikeferguson, @tfoote