### PR TITLE
add rule to import backport of trollius to trusty

### DIFF
--- a/config/python-trollius.backport.yaml
+++ b/config/python-trollius.backport.yaml
@@ -1,0 +1,6 @@
+name: trollius
+method: http://ppa.launchpad.net/wjwwood/trollius-backports/ubuntu
+suites: [trusty]
+component: main
+architectures: [any]
+filter_formula: Package (== python-trollius) | Package (== python3-trollius)


### PR DESCRIPTION
This is needed to release `osrf_pycommon` on Trusty. The `python[3]-trollius` debs start up in vivid, so we'll have trusty and vivid+. Since I am using launchpad, I can't easily create backports for EOL Ubuntu distributions (like utopic).