### PR TITLE
added arm debs

### DIFF
--- a/config/colladadom.upstream.yaml
+++ b/config/colladadom.upstream.yaml
@@ -5,5 +5,5 @@ name: colladadomppa
 method: http://ppa.launchpad.net/openrave/testing/ubuntu
 suites: [saucy, trusty, utopic, vivid, wily]
 component: main
-architectures: [i386, amd64, source]
+architectures: [i386, amd64, armhf, arm64, source]
 filter_formula: Package (% *collada-dom* )


### PR DESCRIPTION
is this ok? we have trusty, vivid, wily, we do not have arm deb for saucy and utopic due to they are EOL on launchpad builder.