### PR TITLE
Use source package in update rule filter

### DIFF
--- a/config/catkin_lint.upstream.yaml
+++ b/config/catkin_lint.upstream.yaml
@@ -3,4 +3,4 @@ method: http://ppa.launchpad.net/roehling/latest/ubuntu
 suites: [precise, trusty, utopic, vivid, wily, xenial, yakkety, zesty]
 component: main
 architectures: [i386, amd64, source]
-filter_formula: Package (== catkin-lint ) | Package (% python*-catkin-lint)
+filter_formula: Source (== catkin-lint)


### PR DESCRIPTION
By using the `Source` filter, the update rule will continue to function even if binary packages are renamed or removed. Everything built from the `catkin-lint` source package will be matched by the rule.