### PR TITLE
Fail script in case of failed subcommands

### DIFF
--- a/src/reprepro_updater/helpers.py
+++ b/src/reprepro_updater/helpers.py
@@ -162,8 +162,10 @@ def run_cleanup(repo_dir, rosdistro, distro, arch, commit):
     lockfile = os.path.join(repo_dir, 'lock')
     with LockContext(lockfile) as lock_c:
 
-        _clear_ros_distro(repo_dir, rosdistro, distro, arch, commit)
-        delete_unreferenced(repo_dir, commit)
+        if not _clear_ros_distro(repo_dir, rosdistro, distro, arch, commit):
+            raise RuntimeError('cleanup command failed')
+        if not delete_unreferenced(repo_dir, commit):
+            raise RuntimeError('delete_unreferenced command failed')
 
 
 def run_update(repo_dir, dist_generator, updates_generator,
@@ -190,4 +192,5 @@ def run_update(repo_dir, dist_generator, updates_generator,
         with open(distributions_filename, 'w') as fh:
             fh.write(dist_generator.generate_file_contents(arch))
 
-        _run_update_command(repo_dir, distro, commit)
+        if not _run_update_command(repo_dir, distro, commit):
+            raise RuntimeError('update command failed')


### PR DESCRIPTION
Based on top of #48.

If any of the invoked subcommands failed (e.g. search for "returned non-zero exit status" in http://build.ros.org:8080/job/import_upstream/125/consoleFull) the script should fail and not "hide" the problem in the hundres of kb of output.