### PR TITLE
Improve performance of include_folder.py

### DIFF
--- a/src/reprepro_updater/helpers.py
+++ b/src/reprepro_updater/helpers.py
@@ -167,10 +167,10 @@ def invalidate_dependent(repo_dir, distro, arch, package):
     # on the buildfarm when invalidating low-level packages.
     repo_info = RepositoryInfo(repo_dir, distro, arch)
 
-    # queue of dependents to iterate
-    dependents_to_process = repo_info.get_rdepends(package)
-    # the complete list of transitive dependents
-    transitive_dependents = dependents_to_process.copy()
+    # We'll build this into a list of transitive dependents.
+    transitive_dependents = repo_info.get_rdepends(package)
+    # queue of dependents to iterate, seeded with the initial rdepends.
+    dependents_to_process = list(transitive_dependents)
 
     queue_max_size = len(dependents_to_process)
     processed_packages = 0
@@ -179,7 +179,7 @@ def invalidate_dependent(repo_dir, distro, arch, package):
         _start = time.time()
         dep = dependents_to_process.pop()
         depdeps = repo_info.get_rdepends(dep)
-        dependents_to_process |= (depdeps - transitive_dependents)
+        dependents_to_process += (depdeps - transitive_dependents)
         transitive_dependents |= depdeps
 
         if len(dependents_to_process) > queue_max_size:

--- a/src/reprepro_updater/helpers.py
+++ b/src/reprepro_updater/helpers.py
@@ -129,23 +129,11 @@ def invalidate_dependent(repo_dir, distro, arch, package):
     # queue of dependents to iterate, seeded with the initial rdepends.
     dependents_to_process = list(transitive_dependents)
 
-    queue_max_size = len(dependents_to_process)
-    processed_packages = 0
-    iter_times = []
     while dependents_to_process:
-        _start = time.time()
         dep = dependents_to_process.pop()
         depdeps = repo_info.get_rdepends(dep)
         dependents_to_process += (depdeps - transitive_dependents)
         transitive_dependents |= depdeps
-
-        if len(dependents_to_process) > queue_max_size:
-            queue_max_size = len(dependents_to_process)
-        processed_packages += 1
-        iter_times.append(time.time() - _start)
-        print("Queue size:\t\t{}".format(len(dependents_to_process)))
-        print("Dependents found:\t{}".format(len(transitive_dependents)))
-        print("Avg iter time:\t\t{}".format(sum(iter_times) / len(iter_times)))
 
     return invalidate_packages(repo_dir, distro, arch, transitive_dependents)
 

--- a/src/reprepro_updater/helpers.py
+++ b/src/reprepro_updater/helpers.py
@@ -159,9 +159,17 @@ def invalidate_dependent(repo_dir, distro, arch, package):
 
     This is only valid for binary packages.
     """
-    # storage for recursion
-    processed_packages = []
-    return _invalidate_dependent(repo_dir, distro, arch, package, processed_packages)
+    # queue of dependents to iterate
+    dependents_to_process = set(_get_dependent_packages(repo_dir, distro, arch, package))
+    # the complete list of transitive dependents
+    transitive_dependents = dependents_to_process.copy()
+    while len(dependents_to_process) > 0:
+        dep = dependents_to_process.pop
+        depdeps = set(_get_dependent_packages(repo_dir, distro, arch, dep))
+        dependents_to_process |= (depdeps - transitive_dependents)
+        transitive_dependents |= depdeps
+
+    return invalidate_packages(repo_dir, distro, arch, transitive_dependents)
 
 
 def _clear_ros_distro(repo_dir, rosdistro, distro, arch, commit):

--- a/src/reprepro_updater/helpers.py
+++ b/src/reprepro_updater/helpers.py
@@ -164,7 +164,7 @@ def invalidate_dependent(repo_dir, distro, arch, package):
     # the complete list of transitive dependents
     transitive_dependents = dependents_to_process.copy()
     while len(dependents_to_process) > 0:
-        dep = dependents_to_process.pop
+        dep = dependents_to_process.pop()
         depdeps = set(_get_dependent_packages(repo_dir, distro, arch, dep))
         dependents_to_process |= (depdeps - transitive_dependents)
         transitive_dependents |= depdeps

--- a/src/reprepro_updater/helpers.py
+++ b/src/reprepro_updater/helpers.py
@@ -175,7 +175,7 @@ def invalidate_dependent(repo_dir, distro, arch, package):
     queue_max_size = len(dependents_to_process)
     processed_packages = 0
     iter_times = []
-    while len(dependents_to_process) > 0:
+    while dependents_to_process:
         _start = time.time()
         dep = dependents_to_process.pop()
         depdeps = repo_info.get_rdepends(dep)

--- a/src/reprepro_updater/helpers.py
+++ b/src/reprepro_updater/helpers.py
@@ -133,7 +133,11 @@ def invalidate_packages(repo_dir, distro, arch, packages):
 
     This is only valid for binary packages.
     """
-    filterstr = "Package (== {})"
+    # Short circuit if there are no packages to remove.
+    if not packages:
+        print('No packages to remove. Not invoking reprepro.')
+        return True
+    filterstr = 'Package (== {})'
     filterlist = [filterstr.format(pkgname) for pkgname in packages]
     invalidate_packages_command = ['reprepro', '-b', repo_dir,
                                    '-T', 'deb', '-A', arch, '-V',
@@ -151,7 +155,7 @@ def invalidate_package(repo_dir, distro, arch, package):
     invalidate_package_command = ['reprepro', '-b', repo_dir,
                                   '-T', debtype, '-V',
                                   'removefilter', distro,
-                                  "Package (== " + package + " )" + arch_match]
+                                  'Package (== ' + package + ' )' + arch_match]
     return try_run_command(invalidate_package_command)
 
 

--- a/src/reprepro_updater/helpers.py
+++ b/src/reprepro_updater/helpers.py
@@ -125,6 +125,21 @@ def _invalidate_dependent(repo_dir, distro, arch, package, processed_packages):
     return True
 
 
+def invalidate_packages(repo_dir, distro, arch, packages):
+    """
+    Remove multiple packages from the repo in one reprepro invocation.
+
+    This is only valid for binary packages.
+    """
+    filterstr = "Package (== {})"
+    filterlist = [filterstr.format(pkgname) for pkgname in packages]
+    invalidate_packages_command = ['reprepro', '-b', repo_dir,
+                                   '-T', 'deb', '-A', arch, '-V',
+                                   'removefilter', distro,
+                                   ' | '.join(filterlist)]
+    return try_run_command(invalidate_packages_command)
+
+
 def invalidate_package(repo_dir, distro, arch, package):
     """Remove this package itself from the repo."""
     debtype = 'deb' if arch != 'source' else 'dsc'

--- a/src/reprepro_updater/helpers.py
+++ b/src/reprepro_updater/helpers.py
@@ -163,11 +163,24 @@ def invalidate_dependent(repo_dir, distro, arch, package):
     dependents_to_process = set(_get_dependent_packages(repo_dir, distro, arch, package))
     # the complete list of transitive dependents
     transitive_dependents = dependents_to_process.copy()
+
+    queue_max_size = len(dependents_to_process)
+    processed_packages = 0
+    iter_times = []
     while len(dependents_to_process) > 0:
+        _start = time.time()
         dep = dependents_to_process.pop()
         depdeps = set(_get_dependent_packages(repo_dir, distro, arch, dep))
         dependents_to_process |= (depdeps - transitive_dependents)
         transitive_dependents |= depdeps
+
+        if len(dependents_to_process) > queue_max_size:
+            queue_max_size = len(dependents_to_process)
+        processed_packages += 1
+        iter_times.append(time.time() - _start)
+        print("Queue size:\t\t" + len(dependents_to_process))
+        print("Dependents found:\t" + len(transitive_dependents))
+        print("Avg iter time:\t\t" + sum(iter_times) / len(iter_times))
 
     return invalidate_packages(repo_dir, distro, arch, transitive_dependents)
 

--- a/src/reprepro_updater/helpers.py
+++ b/src/reprepro_updater/helpers.py
@@ -178,9 +178,9 @@ def invalidate_dependent(repo_dir, distro, arch, package):
             queue_max_size = len(dependents_to_process)
         processed_packages += 1
         iter_times.append(time.time() - _start)
-        print("Queue size:\t\t" + len(dependents_to_process))
-        print("Dependents found:\t" + len(transitive_dependents))
-        print("Avg iter time:\t\t" + sum(iter_times) / len(iter_times))
+        print("Queue size:\t\t{}".format(len(dependents_to_process)))
+        print("Dependents found:\t{}".format(len(transitive_dependents)))
+        print("Avg iter time:\t\t{}".format(sum(iter_times) / len(iter_times)))
 
     return invalidate_packages(repo_dir, distro, arch, transitive_dependents)
 

--- a/src/reprepro_updater/helpers.py
+++ b/src/reprepro_updater/helpers.py
@@ -80,7 +80,7 @@ def _run_update_command(repo_dir, distro, commit):
 
 def _get_dependent_packages(repo_dir, distro, arch, package):
     """
-    Return a list of packages which were detected as dependant by reprepro.
+    Return a list of packages which were detected as dependent by reprepro.
 
     This only returns direct dependencies.
     """

--- a/src/reprepro_updater/repository_info.py
+++ b/src/reprepro_updater/repository_info.py
@@ -42,7 +42,12 @@ class RepositoryInfo:
                 raise RuntimeError(
                     "Repository file '{}' had a section missing 'Package':\n+\n{}\n+".format(
                         packages_filepath, section))
-            self.package_dependencies[name.strip()] = depends
+            name = name.strip()
+            # Drop packages from the list of packages that are not named as ros packages.
+            # This matches the behavior of the _get_dependent_packages reprepro filter.
+            if not name.startswith('ros-'):
+                continue
+            self.package_dependencies[name] = depends
         return self.package_dependencies
 
     def get_rdepends(self, package):

--- a/src/reprepro_updater/repository_info.py
+++ b/src/reprepro_updater/repository_info.py
@@ -2,9 +2,8 @@ import os
 
 
 class RepositoryInfo:
-    """
-    Parse apt repository data in order to provide information for reprepro-updater.
-    """
+    """Parse apt repository data in order to provide information for reprepro-updater."""
+
     def __init__(self, repo_dir, distro, arch):
         self.repo_dir = repo_dir
         self.distro = distro
@@ -14,37 +13,35 @@ class RepositoryInfo:
 
     def _parse_packages_file(self):
         """
-
-        Loads the Packages file for the main repository component and parses
-        the dependencies into memory.
+        Parse main apt Packages file and load dependencies into memory.
 
         Sets the variable package_dependencies which is a dict of package names
         mapping to sets of dependency names.
         """
         if self.package_dependencies is None:
             self.package_dependencies = {}
-        packages_filepath = os.path.join(self.repo_dir, 'dists', self.distro,
-                                         'main', 'binary-{}'.format(self.arch), 'Packages')
-        packages_contents = open(packages_filepath, "r").read()
-        for section in packages_contents.split("\n\n"):
+        packages_filepath = os.path.join(
+            self.repo_dir, 'dists', self.distro,
+            'main', 'binary-{}'.format(self.arch), 'Packages')
+        packages_contents = open(packages_filepath, 'r').read()
+        for section in packages_contents.split('\n\n'):
             if section is '':
                 continue
             name = None
             depends = None
-            for line in section.split("\n"):
-                if line.startswith("Package: "):
-                    name = line.split(": ")[1]
-                if line.startswith("Depends: "):
-                    depends = line.split(": ")[1]
+            for line in section.split('\n'):
+                if line.startswith('Package: '):
+                    name = line.split(': ')[1]
+                if line.startswith('Depends: '):
+                    depends = {
+                        item.strip().split(' ')[0] for item in line.split(': ')[1].split(',')}
             if name is None:
                 raise RuntimeError(
                     "Repository file '{}' had a section missing 'Package':\n+\n{}\n+".format(
                         packages_filepath, section))
             if depends is None:
-                dependency_set = set()
-            else:
-                dependency_set = set([item.strip().split(' ')[0] for item in depends.split(',')])
-            self.package_dependencies[name.strip()] = dependency_set
+                depends = set()
+            self.package_dependencies[name.strip()] = depends
         return self.package_dependencies
 
     def get_rdepends(self, package):

--- a/src/reprepro_updater/repository_info.py
+++ b/src/reprepro_updater/repository_info.py
@@ -29,7 +29,7 @@ class RepositoryInfo:
             if section is '':
                 continue
             name = None
-            depends = None
+            depends = set()
             for line in section.split('\n'):
                 if line.startswith('Package: '):
                     name = line.split(': ')[1]
@@ -40,8 +40,6 @@ class RepositoryInfo:
                 raise RuntimeError(
                     "Repository file '{}' had a section missing 'Package':\n+\n{}\n+".format(
                         packages_filepath, section))
-            if depends is None:
-                depends = set()
             self.package_dependencies[name.strip()] = depends
         return self.package_dependencies
 

--- a/src/reprepro_updater/repository_info.py
+++ b/src/reprepro_updater/repository_info.py
@@ -34,8 +34,10 @@ class RepositoryInfo:
                 if line.startswith('Package: '):
                     name = line.split(': ')[1]
                 if line.startswith('Depends: '):
-                    depends = {
-                        item.strip().split(' ')[0] for item in line.split(': ')[1].split(',')}
+                    depends = {pkg.strip().split(' ')[0] for pkg in line.split(': ')[1].split(',')}
+                    # Drop packages from the rdepends chain that are not named as ros packages.
+                    # This matches the behavior of the _get_dependent_packages reprepro filter.
+                    depends = [pkg for pkg in depends if pkg.startswith('ros-')]
             if name is None:
                 raise RuntimeError(
                     "Repository file '{}' had a section missing 'Package':\n+\n{}\n+".format(

--- a/src/reprepro_updater/repository_info.py
+++ b/src/reprepro_updater/repository_info.py
@@ -58,7 +58,7 @@ class RepositoryInfo:
 
         # Early return a memoized result if previously calculated.
         if package in self.package_rdepends:
-            return self.package_rdepends[package]
+            return self.package_rdepends[package].copy()
 
         rdepends = set()
         for p, dependencies in self.package_dependencies.items():
@@ -66,4 +66,4 @@ class RepositoryInfo:
                 rdepends.add(p)
         self.package_rdepends[package] = rdepends
 
-        return self.package_rdepends[package]
+        return self.package_rdepends[package].copy()

--- a/src/reprepro_updater/repository_info.py
+++ b/src/reprepro_updater/repository_info.py
@@ -35,7 +35,7 @@ class RepositoryInfo:
                     name = line.split(': ')[1]
                 if line.startswith('Depends: '):
                     depends = {pkg.strip().split(' ')[0] for pkg in line.split(': ')[1].split(',')}
-                    # Drop packages from the rdepends chain that are not named as ros packages.
+                    # Drop packages from the dependency chain that are not named as ros packages.
                     # This matches the behavior of the _get_dependent_packages reprepro filter.
                     depends = [pkg for pkg in depends if pkg.startswith('ros-')]
             if name is None:

--- a/src/reprepro_updater/repository_info.py
+++ b/src/reprepro_updater/repository_info.py
@@ -23,7 +23,8 @@ class RepositoryInfo:
         packages_filepath = os.path.join(
             self.repo_dir, 'dists', self.distro,
             'main', 'binary-{}'.format(self.arch), 'Packages')
-        packages_contents = open(packages_filepath, 'r').read()
+        with open(packages_filepath, 'r') as packages_file:
+            packages_contents = packages_file.read()
         for section in packages_contents.split('\n\n'):
             if section is '':
                 continue

--- a/src/reprepro_updater/repository_info.py
+++ b/src/reprepro_updater/repository_info.py
@@ -9,7 +9,7 @@ class RepositoryInfo:
         self.distro = distro
         self.arch = arch
         self.package_dependencies = None
-        self.package_rdepends = None
+        self.package_rdepends = {}
 
     def _parse_packages_file(self):
         """
@@ -57,8 +57,6 @@ class RepositoryInfo:
         Uses an internal map of memoized return values to cache results.
         Returns a set of package names that depend directly on the given package.
         """
-        if self.package_rdepends is None:
-            self.package_rdepends = {}
         if self.package_dependencies is None:
             self._parse_packages_file()
 

--- a/src/reprepro_updater/repository_info.py
+++ b/src/reprepro_updater/repository_info.py
@@ -1,0 +1,72 @@
+import os
+
+
+class RepositoryInfo:
+    """
+    Parse apt repository data in order to provide information for reprepro-updater.
+    """
+    def __init__(self, repo_dir, distro, arch):
+        self.repo_dir = repo_dir
+        self.distro = distro
+        self.arch = arch
+        self.package_dependencies = None
+        self.package_rdepends = None
+
+    def _parse_packages_file(self):
+        """
+
+        Loads the Packages file for the main repository component and parses
+        the dependencies into memory.
+
+        Sets the variable package_dependencies which is a dict of package names
+        mapping to sets of dependency names.
+        """
+        if self.package_dependencies is None:
+            self.package_dependencies = {}
+        packages_filepath = os.path.join(self.repo_dir, 'dists', self.distro,
+                                         'main', 'binary-{}'.format(self.arch), 'Packages')
+        packages_contents = open(packages_filepath, "r").read()
+        for section in packages_contents.split("\n\n"):
+            if section is '':
+                continue
+            name = None
+            depends = None
+            for line in section.split("\n"):
+                if line.startswith("Package: "):
+                    name = line.split(": ")[1]
+                if line.startswith("Depends: "):
+                    depends = line.split(": ")[1]
+            if name is None:
+                raise RuntimeError(
+                    "Repository file '{}' had a section missing 'Package':\n+\n{}\n+".format(
+                        packages_filepath, section))
+            if depends is None:
+                dependency_set = set()
+            else:
+                dependency_set = set([item.strip().split(' ')[0] for item in depends.split(',')])
+            self.package_dependencies[name.strip()] = dependency_set
+        return self.package_dependencies
+
+    def get_rdepends(self, package):
+        """
+        Get the direct reverse dependencies (dependents) of the given package.
+
+        Uses an internal map of memoized return values to cache results.
+        Returns a set of package names that depend directly on the given package.
+        """
+        if self.package_rdepends is None:
+            self.package_rdepends = {}
+        if self.package_dependencies is None:
+            self._parse_packages_file()
+
+        # Early return a memoized result if previously calculated.
+        if package in self.package_rdepends:
+            return self.package_rdepends[package]
+
+        rdepends = set()
+        for p, dependencies in self.package_dependencies.items():
+            if package in dependencies:
+                rdepends.add(p)
+        self.package_rdepends[package] = rdepends
+
+        return self.package_rdepends[package]


### PR DESCRIPTION
I spent time Friday and Saturday trying to investigate the performance issues ticketed in https://github.com/ros-infrastructure/buildfarm_deployment/issues/165

### Test case

My main test case is rebuilding catkin on indigo trusty amd64

My test farm isn't quite the same as the production farm. It's a little under-powered but that makes it easier to test the impact of performance improvements.

With a fresh import of indigo from the production repositories the first catkin import package job takes ~2.5 hours. Which is enough to make the catkin build job timeout and require a second run to complete successfully. Since the import package job does clean out the repositories, subsequent package imports complete within normal range because everything must be rebuilt.

### Optimization strategy

Since we had fewer issues with the same reprepro version (5.1.1) on the Trusty farm, which was using the zesty amd64 deb copied directly rather than a homemade backport of the zesty deb for Xenial, which is what the current farm uses, I first tried installing that zesty deb on my testfarm. This resulted in no change to job time or behavior.

reprepro's apparent maintenance status, our [other issues with it](https://github.com/ros-infrastructure/buildfarm_deployment/issues/186), and the community momentum behind [aptly](https://www.aptly.info/) make us reluctant to invest heavily in trying to improve reprepro itself so for the time being we're going to try and optimize our usage of reprepro.

### First pass

The first optimization was to remove all transitive dependencies with a single invocation of reprepro removefilter. Each run of removefilter required a reindexing to occur.  While I haven't profiled the reindexing separate from the rest of the remove operation. Running the remove filter takes 2.0-2.6s so doing that once instead of ~2000 times will definitely pay dividends.

### Next steps

The next major performance blocker is fetching the transitive dependencies. The current method uses a listfilter query and parses the results, adding each new dependent package to a queue to be processed. This is roughly equivalent to the recursive function tracking seen packages that was in use previously. Both rely on one exec of reprepro listfilter per package to process. Which means that finding catkin's transitive deps requires something like 2000 execs, each of which takes ~1.6sec.

To resolve this it's occurred to me so far to

#### throw compute at it to try and reduce the exec time

This is just straight throwing money at the problem :money_with_wings: I'm not even sure it can help that much since it we'll always have the overhead of the individual execs.

#### parallelize dependency collection

This will also require throwing some extra money at compute in order to get a machine with more processors/threads. We would be able to run a couple execs at once but this wouldn't reduce the overall number of execs and it'd mean making sure that this part of the code is concurrency-safe.

#### Find a way to get all transitive dependents at once

As near as I can tell, there's no way to get transitive dependents with a single reprepro filterlist. Which means that we would need to use something that isn't reprepro.
This is kind of the magic ideal as it replaces a 2k iterative/recursive process with a single-step one. I have no idea how to do it and I am not convinced that it's possible without precompiling the list of transitive dependents for each package.

#### Bring dependent fetching logic in-process

Instead of invoking reprepro filterlist to determine which packages depend on a given package read the repository manifest and do so ourselves in-process. Since I haven't profiled reprepro itself (and ideally don't intend to) I don't know how much time it spends starting up then reading and parsing repository information but it probably isn't negligible. If we can reduce the iteration time even a little we'll reduce the overall runtime significantly.
