### PR TITLE
Rename incoming ddeb files

### DIFF
--- a/scripts/include_folder.py
+++ b/scripts/include_folder.py
@@ -28,7 +28,9 @@ def rename_ddeb_files_in_changes_file(filename):
             if not l.strip().endswith('.ddeb'):
                 trimmed_version.append(l)
             else:
-                ddeb_file = l.strip().split(' ')[4]
+                # Checksum entries have three columns. Files entries have four.
+                # The last is always the filename.
+                ddeb_file = l.strip().split(' ')[-1]
                 deb_file = ddeb_file.replace('.ddeb', '.deb')
                 print('Renaming `%s` to `%s`'.format(ddeb_file, deb_file))
                 os.rename(ddeb_file, deb_file)

--- a/scripts/include_folder.py
+++ b/scripts/include_folder.py
@@ -17,8 +17,8 @@ from reprepro_updater.helpers import LockContext
 from reprepro_updater.helpers import run_include_command
 
 
-def remove_ddeb_from_changes_file(filename):
-    """ Remove ddeb entries from changes file
+def rename_ddeb_files_in_changes_file(filename):
+    """ Rename ddeb files listed in changes file
     This is a workaround for https://github.com/ros-infrastructure/buildfarm_deployment/issues/186
     """
     trimmed_version = []
@@ -28,9 +28,14 @@ def remove_ddeb_from_changes_file(filename):
             if not l.strip().endswith('.ddeb'):
                 trimmed_version.append(l)
             else:
+                ddeb_file = l.strip().split(' ')[4]
+                deb_file = ddeb_file.replace('.ddeb', '.deb')
+                print('Renaming `%s` to `%s`'.format(ddeb_file, deb_file))
+                os.rename(ddeb_file, deb_file)
+                trimmed_version.append(l.replace('.ddeb', '.deb'))
                 changes_made = True
     if changes_made:
-        print('Removing ddeb lines from changes file: %s ' % filename +
+        print('Renamed ddeb files to deb in changes file: %s ' % filename +
               'workaround https://github.com/ros-infrastructure/buildfarm_deployment/issues/186')
         with open(filename, 'w') as changes:
             for l in trimmed_version:
@@ -120,7 +125,7 @@ if options.commit:
             package_str_parts.append(changes.content['Architecture'])
             print('Importing package: %s' % ':'.join(package_str_parts))
 
-            remove_ddeb_from_changes_file(changes.filename)
+            rename_ddeb_files_in_changes_file(changes.filename)
             if not run_include_command(options.repo_path,
                                        changes.content['Distribution'],
                                        changes.filename):

--- a/scripts/include_folder.py
+++ b/scripts/include_folder.py
@@ -32,8 +32,10 @@ def rename_ddeb_files_in_changes_file(filename):
                 # The last is always the filename.
                 ddeb_file = l.strip().split(' ')[-1]
                 deb_file = ddeb_file.replace('.ddeb', '.deb')
-                print('Renaming `%s` to `%s`'.format(ddeb_file, deb_file))
-                os.rename(ddeb_file, deb_file)
+                # Rename the ddeb file if it hasn't been already.
+                if os.path.isfile(ddeb_file):
+                    print('Renaming `%s` to `%s`'.format(ddeb_file, deb_file))
+                    os.rename(ddeb_file, deb_file)
                 trimmed_version.append(l.replace('.ddeb', '.deb'))
                 changes_made = True
     if changes_made:

--- a/scripts/include_folder.py
+++ b/scripts/include_folder.py
@@ -32,7 +32,7 @@ def rename_ddeb_files_in_changes_file(filename):
                 # Checksum entries have three columns. Files entries have four.
                 # The last is always the filename.
                 ddeb_file = l.strip().split(' ')[-1]
-                basename = os.path.splitext(ddeb_file)[1]
+                basename = os.path.splitext(ddeb_file)[0]
                 deb_file = basename + '.deb'
                 # Rename the ddeb file if it hasn't been already.
                 if os.path.isfile(os.path.join(deb_path, ddeb_file)):

--- a/scripts/include_folder.py
+++ b/scripts/include_folder.py
@@ -34,7 +34,7 @@ def rename_ddeb_files_in_changes_file(filename):
                 deb_file = ddeb_file.replace('.ddeb', '.deb')
                 # Rename the ddeb file if it hasn't been already.
                 if os.path.isfile(ddeb_file):
-                    print('Renaming `%s` to `%s`'.format(ddeb_file, deb_file))
+                    print('Renaming `{}` to `{}`'.format(ddeb_file, deb_file))
                     os.rename(ddeb_file, deb_file)
                 trimmed_version.append(l.replace('.ddeb', '.deb'))
                 changes_made = True

--- a/scripts/include_folder.py
+++ b/scripts/include_folder.py
@@ -28,14 +28,15 @@ def rename_ddeb_files_in_changes_file(filename):
             if not l.strip().endswith('.ddeb'):
                 trimmed_version.append(l)
             else:
+                deb_path = os.path.dirname(filename)
                 # Checksum entries have three columns. Files entries have four.
                 # The last is always the filename.
                 ddeb_file = l.strip().split(' ')[-1]
                 deb_file = ddeb_file.replace('.ddeb', '.deb')
                 # Rename the ddeb file if it hasn't been already.
-                if os.path.isfile(ddeb_file):
+                if os.path.isfile(os.path.join(deb_path, ddeb_file)):
                     print('Renaming `{}` to `{}`'.format(ddeb_file, deb_file))
-                    os.rename(ddeb_file, deb_file)
+                    os.rename(os.path.join(deb_path, ddeb_file), os.path.join(deb_path, deb_file))
                 trimmed_version.append(l.replace('.ddeb', '.deb'))
                 changes_made = True
     if changes_made:

--- a/scripts/include_folder.py
+++ b/scripts/include_folder.py
@@ -41,7 +41,7 @@ def rename_ddeb_files_in_changes_file(filename):
                 trimmed_version.append(l.replace(ddeb_file, deb_file))
                 changes_made = True
     if changes_made:
-        print('Renamed ddeb files to deb in changes file: %s ' % filename +
+        print('Renamed ddeb files to deb in changes file: %s ' % filename + ' to ' +
               'workaround https://github.com/ros-infrastructure/buildfarm_deployment/issues/186')
         with open(filename, 'w') as changes:
             for l in trimmed_version:

--- a/scripts/include_folder.py
+++ b/scripts/include_folder.py
@@ -32,12 +32,13 @@ def rename_ddeb_files_in_changes_file(filename):
                 # Checksum entries have three columns. Files entries have four.
                 # The last is always the filename.
                 ddeb_file = l.strip().split(' ')[-1]
-                deb_file = ddeb_file.replace('.ddeb', '.deb')
+                basename = os.path.splitext(ddeb_file)[1]
+                deb_file = basename + '.deb'
                 # Rename the ddeb file if it hasn't been already.
                 if os.path.isfile(os.path.join(deb_path, ddeb_file)):
                     print('Renaming `{}` to `{}`'.format(ddeb_file, deb_file))
                     os.rename(os.path.join(deb_path, ddeb_file), os.path.join(deb_path, deb_file))
-                trimmed_version.append(l.replace('.ddeb', '.deb'))
+                trimmed_version.append(l.replace(ddeb_file, deb_file))
                 changes_made = True
     if changes_made:
         print('Renamed ddeb files to deb in changes file: %s ' % filename +


### PR DESCRIPTION
Reprepro doesn't support *.ddeb files (https://github.com/ros-infrastructure/buildfarm_deployment/issues/186). We've worked around this up until now by removing ddeb entries from the .changes file #55 before importing packages.
However this means that we don't have accessible debug symbols for melodic on artful and bionic.

Empirical testing shows that these "ddeb" packages are pretty much just .debs with a funny file extension. Changing the name doesn't prevent the package from being installed and the dbgsym packages in Debian Stretch (which our buildfarm already has and supports) are just regular .deb packages.

So with this change, instead of just dropping the ddebs from a changes file we rename them to deb and use the changes manifest to find and rename the ddeb files on disk before import.
In order for this change to work we also need to actually send the ddebs to the repo host as they're currently dropped by the publication regexp (PR to ros_buildfarm https://github.com/ros-infrastructure/ros_buildfarm/pull/545).

These changes were tested on a testfarm using the rospack package. Here is a sample of output

```
# BEGIN SECTION: import debian package
06:13:19 + export PYTHONPATH=/home/jenkins-agent/workspace/Mrel_import-package/reprepro-updater/src:
06:13:19 + python -u /home/jenkins-agent/workspace/Mrel_import-package/reprepro-updater/scripts/include_folder.py --folder /var/repos/ubuntu/building/queue/bionic/Mbin_uB64__rospack__ubuntu_bionic_amd64__binary__6 --package ros-melodic-rospack --delete-folder --commit --invalidate
06:13:19 running command ['reprepro', '-b', '/var/repos/ubuntu/building', '-T', 'deb', '-A', u'amd64', '-V', 'removefilter', u'bionic', 'Package (== ros-melodic-rospack-dbgsym)']
06:13:22 removing 'ros-melodic-rospack-dbgsym' from 'bionic|main|amd64'...
06:13:22 Exporting indices...
06:13:22 Successfully created '/var/repos/ubuntu/building/dists/bionic/Release.gpg.new'
06:13:22 Successfully created '/var/repos/ubuntu/building/dists/bionic/InRelease.new'
06:13:22 Deleting files no longer referenced...
06:13:22 deleting and forgetting pool/main/r/ros-melodic-rospack/ros-melodic-rospack-dbgsym_2.5.0-0bionic.20180521.162633_amd64.deb
06:13:22 running command ['reprepro', '-b', '/var/repos/ubuntu/building', '-T', 'deb', '-V', 'removefilter', u'bionic', u'Package (== ros-melodic-rospack ), Architecture (== amd64 )']
06:13:24 removing 'ros-melodic-rospack' from 'bionic|main|amd64'...
06:13:24 Exporting indices...
06:13:24 Successfully created '/var/repos/ubuntu/building/dists/bionic/Release.gpg.new'
06:13:24 Successfully created '/var/repos/ubuntu/building/dists/bionic/InRelease.new'
06:13:24 Deleting files no longer referenced...
06:13:24 deleting and forgetting pool/main/r/ros-melodic-rospack/ros-melodic-rospack_2.5.0-0bionic.20180521.162633_amd64.deb
06:13:24 running ['reprepro', '-v', '-b', '/var/repos/ubuntu/building', 'deleteunreferenced']
06:13:24 running command ['reprepro', '-v', '-b', '/var/repos/ubuntu/building', 'deleteunreferenced']
06:13:25 Importing package: ros-melodic-rospack:2.5.0-0bionic.20180522.131147:bionic:amd64
06:13:25 Renaming `ros-melodic-rospack-dbgsym_2.5.0-0bionic.20180522.131147_amd64.ddeb` to `ros-melodic-rospack-dbgsym_2.5.0-0bionic.20180522.131147_amd64.deb`
06:13:25 Renamed ddeb files to deb in changes file: /var/repos/ubuntu/building/queue/bionic/Mbin_uB64__rospack__ubuntu_bionic_amd64__binary__6/ros-melodic-rospack_2.5.0-0bionic.20180522.131147_amd64.changes workaround https://github.com/ros-infrastructure/buildfarm_deployment/issues/186
06:13:25 running command ['reprepro', '-v', '-b', '/var/repos/ubuntu/building', '-S', 'misc', 'include', u'bionic', '/var/repos/ubuntu/building/queue/bionic/Mbin_uB64__rospack__ubuntu_bionic_amd64__binary__6/ros-melodic-rospack_2.5.0-0bionic.20180522.131147_amd64.changes']

06:13:28 Exporting indices...
06:13:28 Removing /var/repos/ubuntu/building/queue/bionic/Mbin_uB64__rospack__ubuntu_bionic_amd64__binary__6
06:13:28 + echo # END SECTION
06:13:28 # END SECTION
06:13:28 [description-setter] Description set: ros-melodic-rospack:2.5.0-0bionic.20180522.131147:bionic:amd64
06:13:28 No emails were triggered.
```
