### PR TITLE
Import custom gazebo9 for Bionic to solve problems with missing test_fixture lib

### DIFF
--- a/config/gazebo9_ubuntu_bionic.ppa.yaml
+++ b/config/gazebo9_ubuntu_bionic.ppa.yaml
@@ -1,0 +1,8 @@
+# include the fix for server_fixture while Ubuntu merges the patch:
+# https://bugs.launchpad.net/ubuntu/+source/gazebo/+bug/1773811
+name: gazebo9_import_ubuntu_bionic
+method: http://ppa.launchpad.net/j-rivero/gazebo9bionic/ubuntu
+suites: [bionic]
+component: main
+architectures: [amd64, i386, armhf, arm64, source]
+filter_formula: Package (% *gazebo* )

--- a/config/gazebo9_ubuntu_bionic.ppa.yaml
+++ b/config/gazebo9_ubuntu_bionic.ppa.yaml
@@ -5,4 +5,4 @@ method: http://ppa.launchpad.net/j-rivero/gazebo9bionic/ubuntu
 suites: [bionic]
 component: main
 architectures: [amd64, i386, armhf, arm64, source]
-filter_formula: Package (% *gazebo* )
+filter_formula: Package (% gazebo9-common ) | Package (% gazebo9-doc ) | Package (% gazebo9-plugin-base ) | Package (% gazebo9 ) | Package (% libgazebo9-dev ) | Package (% libgazebo9 )


### PR DESCRIPTION
Custom build of gazebo 9.0.0 (version in Bionic repos) with a minimal patch to include static libraries.

Details in the SRU bug:
https://bugs.launchpad.net/ubuntu/+source/gazebo/+bug/1773811