### PR TITLE
Add config for importing libopensplice69.

### DIFF
--- a/config/opensplice69.osrfoundation.yaml
+++ b/config/opensplice69.osrfoundation.yaml
@@ -1,0 +1,8 @@
+name: opensplice69
+method: http://packages.osrfoundation.org/gazebo/ubuntu-stable
+suites: [xenial, bionic]
+component: main
+architectures: [amd64, arm64, source]
+filter_formula: Package (% libopensplice69 )
+# needed unless we incorporate the right gpg key
+verify_release: blindtrust


### PR DESCRIPTION
FYI @tfoote and @dirk-thomas I'm merging this to use it.

Imports packages built by https://build.osrfoundation.org/job/opensplice-debbuilder/ and supersedes the existing configuration in the ROS 2 buildfarm_deployment_config.