### PR TITLE
Skip source architecture before error is raised.

### DIFF
--- a/scripts/sync_ros_packages.py
+++ b/scripts/sync_ros_packages.py
@@ -102,6 +102,9 @@ for ubuntu_distro in distros:
             ubuntu_distro,
             'main',
             package_architecture)
+        if arch == 'source':
+            print("Not computing diff for source architecture.", file=sys.stderr)
+            continue
         try:
             pf_old = diff_repos.get_packagefile_from_url(target_url, name='old')
         except RuntimeError as ex:

--- a/scripts/sync_ros_packages.py
+++ b/scripts/sync_ros_packages.py
@@ -78,6 +78,10 @@ dist = conf_params.create_distributions_file(updates_generator)
 
 for ubuntu_distro in distros:
     for arch in arches:
+        # Source architecture doesn't provide a Packages file to diff with.
+        if arch == 'source':
+            print("Not computing diff for source architecture.", file=sys.stderr)
+            continue
 
         d = {'name': 'ros-%s-%s-%s' %
              (options.rosdistro, ubuntu_distro, arch),
@@ -102,9 +106,6 @@ for ubuntu_distro in distros:
             ubuntu_distro,
             'main',
             package_architecture)
-        if arch == 'source':
-            print("Not computing diff for source architecture.", file=sys.stderr)
-            continue
         try:
             pf_old = diff_repos.get_packagefile_from_url(target_url, name='old')
         except RuntimeError as ex:


### PR DESCRIPTION
This doesn't change behavior, source diffs are already omitted because they lack Packages files. This change prints a message that does not contain the word "Exception" before continuing with the sync.