### PR TITLE
Import lark-parser into stretch as well as xenial and bionic.

### DIFF
--- a/config/lark-parser.osrfoundation.yaml
+++ b/config/lark-parser.osrfoundation.yaml
@@ -1,6 +1,6 @@
 name: lark-parser
 method: http://packages.osrfoundation.org/gazebo/ubuntu-stable
-suites: [xenial, bionic]
+suites: [xenial, bionic, stretch]
 component: main
 architectures: [amd64, arm64, source]
 filter_formula: Package (% python3-lark-parser* )


### PR DESCRIPTION
The deb is built and present here http://packages.osrfoundation.org/gazebo/debian-stable/pool/main/l/lark-parser/