### PR TITLE
Fix lark-parser import on Debian Stretch

### DIFF
--- a/config/lark-parser.debian.osrfoundation.yaml
+++ b/config/lark-parser.debian.osrfoundation.yaml
@@ -1,6 +1,6 @@
 name: lark-parser
-method: http://packages.osrfoundation.org/gazebo/ubuntu-stable
-suites: [xenial, bionic]
+method: http://packages.osrfoundation.org/gazebo/debian-stable
+suites: [stretch]
 component: main
 architectures: [amd64, arm64, source]
 filter_formula: Package (% python3-lark-parser* )


### PR DESCRIPTION
The ubuntu-stable and debian-stable repositories on packages.osrfoundation.org are not mutual symlinks.

This effectively reverts #67 and replaces it with a separate config that pulls the Debian package for Stretch from the debian-stable repo. To update lark-parser in the future both configs will need to be run.

This config was hand deployed and run on the build farm to produce http://build.ros2.org/job/import_upstream/165/