### PR TITLE
Add config for importing pycryptodome and reintroduce source_suite option

### DIFF
--- a/config/pycryptodome.yaml
+++ b/config/pycryptodome.yaml
@@ -1,0 +1,10 @@
+name: pycryptodome
+method: http://deb.debian.org/debian
+suites: [stretch]
+source_suite: stretch-backports
+component: main
+architectures: [amd64, arm64, source]
+filter_formula: $Source (==pycryptodome)
+# needed unless we incorporate the right gpg key
+verify_release: blindtrust
+

--- a/src/reprepro_updater/conf.py
+++ b/src/reprepro_updater/conf.py
@@ -153,9 +153,10 @@ Update: %(update_rule)s
 
 class UpdateElement(object):
     def __init__(self, name, method, suites, component, architectures,
-                 filter_formula=None, verify_release=None):
+                 filter_formula=None, source_suite=None, verify_release=None):
         self.name = name
         self.method = method
+        self.source_suite = source_suite
         self.suites = suites
         self.component = component
         self.architectures = architectures
@@ -170,7 +171,7 @@ class UpdateElement(object):
         output = ''
         output += 'Name: %s\n' % self.name
         output += 'Method: %s\n' % self.method
-        output += 'Suite: %s\n' % distro
+        output += 'Suite: %s\n' % (self.source_suite if self.source_suite else distro)
         output += 'Components: %s\n' % self.component
         output += 'Architectures: %s\n' % arch
         if self.filter_formula:


### PR DESCRIPTION
This will pull in python-pycryptodome, python3-pycryptodome, and python-pycryptodome-doc. Only the first is strictly necessary but I feel like it makes more sense to grab the full set.

To enable this to work I had to re-introduce support for the source_suite option which appears to have been removed in the refactor branch (or was added to master and not propagated, I have not done the spelunking to find out).

I dry-ran this using a local checkout on a repository host and it would have added the following packages:

```
add 'python-pycryptodome' - '3.4.7-1~bpo9+1' 'pycryptodome'
add 'python-pycryptodome-doc' - '3.4.7-1~bpo9+1' 'pycryptodome'
add 'python3-pycryptodome' - '3.4.7-1~bpo9+1' 'pycryptodome'
add 'python-pycryptodome' - '3.4.7-1~bpo9+1' 'pycryptodome'
add 'python-pycryptodome-doc' - '3.4.7-1~bpo9+1' 'pycryptodome'
add 'python3-pycryptodome' - '3.4.7-1~bpo9+1' 'pycryptodome'
add 'pycryptodome' - '3.4.7-1~bpo9+1' 'pycryptodome'
```

The binary packages are listed twice since they're being added to both amd64 and arm64 repositories.