### PR TITLE
Add focal to list of distros

### DIFF
--- a/src/reprepro_updater/conf.py
+++ b/src/reprepro_updater/conf.py
@@ -35,7 +35,7 @@ import os
 ALL_DISTROS = ['hardy', 'jaunty', 'karmic', 'lucid', 'maverick',
                'natty', 'oneiric', 'precise', 'quantal', 'raring',
                'saucy', 'trusty', 'utopic', 'vivid', 'wily', 'xenial',
-               'yakkety', 'zesty', 'artful', 'bionic',
+               'yakkety', 'zesty', 'artful', 'bionic', 'focal',
                'wheezy', 'jessie', 'stretch', 'buster']
 ALL_ARCHES =  ['amd64', 'i386', 'arm64', 'armel', 'armhf', 'source']
 


### PR DESCRIPTION
Mimicking #51 

I'm not 100% sure this is still relevant since it sounds like this is a prerequisite to create a `focal` bootstrap repo https://github.com/ros-infrastructure/reprepro-updater/pull/51#issuecomment-354878527, but [one already exists](http://repos.ros.org/repos/ros_bootstrap/dists/focal/).