### PR TITLE
Avoid reading Binary section if in a source changes file.

### DIFF
--- a/scripts/include_folder.py
+++ b/scripts/include_folder.py
@@ -54,9 +54,9 @@ def get_packages_from_changes_file(changes):
     According to the RFC it's mandatory but it's been moved away from for source only packages.
     """
     if changes.content['Architecture'] == 'source':
-        return e.content['Source'].split()
+        return changes.content['Source'].split()
     else:
-        return e.content['Binary'].split()
+        return changes.content['Binary'].split()
 
 
 parser = OptionParser()


### PR DESCRIPTION
Fixes #73 
According to the RFC it's mandatory but it's been moved away from for source only packages.

Signed-off-by: Tully Foote <tfoote@osrfoundation.org>