### PR TITLE
Add gazebo11 Debian Buster and Ubuntu Focal

### DIFF
--- a/config/gazebo11_debian_buster.yaml
+++ b/config/gazebo11_debian_buster.yaml
@@ -1,0 +1,6 @@
+name: gazebo11_debian_buster.yaml
+method: http://packages.osrfoundation.org/gazebo/debian-stable
+suites: [buster]
+component: main
+architectures: [amd64, source]
+filter_formula: Package (% gazebo11-common ) | Package (% gazebo11-dbg ) | Package (% gazebo11-doc ) | Package (% gazebo11-plugin-base ) | Package (% gazebo11 ) | Package (% libgazebo11-dev ) | Package (% libgazebo11 ) | Package (% libignition-common3-av-dev ) | Package (% libignition-common3-core-dev ) | Package (% libignition-common3-events-dev ) | Package (% libignition-common3-graphics-dev ) | Package (% libignition-common3-profiler-dev ) | Package (% libignition-transport8-dev ) | Package (% libignition-transport8-core-dev ) | Package (% libignition-transport8-log-dev ) | Package (% libignition-transport8-log ) | Package (% libignition-transport8-dbg ) | Package (% libignition-fuel-tools4-dev ) | Package (% libignition-fuel-tools4 ) | Package (% libignition-math6-dbg ) | Package (% libignition-math6-dev ) | Package (% libignition-math6 ) | Package (% libignition-msgs5-dbg ) | Package (% libignition-msgs5-dev ) | Package (% libignition-msgs5 ) | Package (% libsdformat9-dbg ) | Package (% libsdformat9-dev ) | Package (% libsdformat9 ) | Package (% sdformat9-sdf ) | Package (% sdformat9-doc ) | Package (% sdformat9-dbg )

--- a/config/gazebo11_ubuntu_focal.yaml
+++ b/config/gazebo11_ubuntu_focal.yaml
@@ -1,0 +1,6 @@
+name: gazebo11_ubuntu_focal.yaml
+method: http://packages.osrfoundation.org/gazebo/ubuntu-stable
+suites: [focal]
+component: main
+architectures: [amd64, source]
+filter_formula: Package (% gazebo11-common ) | Package (% gazebo11-dbg ) | Package (% gazebo11-doc ) | Package (% gazebo11-plugin-base ) | Package (% gazebo11 ) | Package (% libgazebo11-dev ) | Package (% libgazebo11 ) | Package (% libignition-common3-av-dev ) | Package (% libignition-common3-core-dev ) | Package (% libignition-common3-events-dev ) | Package (% libignition-common3-graphics-dev ) | Package (% libignition-common3-profiler-dev ) | Package (% libignition-transport8-dev ) | Package (% libignition-transport8-core-dev ) | Package (% libignition-transport8-log-dev ) | Package (% libignition-transport8-log ) | Package (% libignition-transport8-dbg ) | Package (% libignition-fuel-tools4-dev ) | Package (% libignition-fuel-tools4 ) | Package (% libignition-math6-dbg ) | Package (% libignition-math6-dev ) | Package (% libignition-math6 ) | Package (% libignition-msgs5-dbg ) | Package (% libignition-msgs5-dev ) | Package (% libignition-msgs5 ) | Package (% libsdformat9-dbg ) | Package (% libsdformat9-dev ) | Package (% libsdformat9 ) | Package (% sdformat9-sdf ) | Package (% sdformat9-doc ) | Package (% sdformat9-dbg )


### PR DESCRIPTION
For both, Noetic (ROS1) and Foxy (ROS2) we need to import gazebo11 packages together with all its dependencies. I added two files here to import all the needed files from packages.osrfoundation.org. 

Some packages are affected by https://github.com/ignition-tooling/release-tools/issues/186 and don't have -dbg packages. I think this should not stop us from starting the upload in order to unblock the `gazebo_ros_pkgs` porting, testing and release.

/cc @chapulina 