### PR TITLE
add vcstool upstream config

### DIFF
--- a/config/vcstool.debian.upstream.yaml
+++ b/config/vcstool.debian.upstream.yaml
@@ -1,0 +1,6 @@
+name: vcstool
+method: https://packagecloud.io/dirk-thomas/vcstool/debian
+suites: [jessie, stretch, buster]
+component: main
+architectures: [i386, amd64, armhf, arm64, source]
+filter_formula: Package (% python3-vcstool, $Version (% 0.2.14*)

--- a/config/vcstool.ubuntu.upstream.yaml
+++ b/config/vcstool.ubuntu.upstream.yaml
@@ -1,0 +1,6 @@
+name: vcstool
+method: https://packagecloud.io/dirk-thomas/vcstool/ubuntu
+suites: [xenial, bionic, focal]
+component: main
+architectures: [i386, amd64, armhf, arm64, source]
+filter_formula: Package (% python3-vcstool, $Version (% 0.2.14*)


### PR DESCRIPTION
To configure the import from the `vcstool` upstream repo https://packagecloud.io/dirk-thomas/vcstool.

This config only contains the Python 2 packages. I intend to do one last Python 2 release directly into the ROS apt repos adding a message that this is the last Python 2 release and users should update to Python 3 packages.