### PR TITLE
Encode announcement print statement

### DIFF
--- a/scripts/sync_ros_packages.py
+++ b/scripts/sync_ros_packages.py
@@ -124,7 +124,7 @@ for ubuntu_distro in distros:
               (target_url, upstream_url, dtime.isoformat('-')))
         announcement = diff_repos.compute_annoucement(options.rosdistro, pf_old, pf_new)
         print('-' * 80)
-        print(announcement)
+        print(announcement.encode('utf-8'))
         print('-' * 80)
 
 # clean up first


### PR DESCRIPTION
Seems like python was having bad time with some characters in print command, probably coming from `Steven! Ragnarök` ;) . I forced the encode to utf8. The job displays the diff:

```
14:25:03 Difference between 'file:///var/repos/ubuntu/testing/dists/bionic/main/binary-amd64/Packages' and 'file:///var/repos/ubuntu/building/dists/bionic/main/binary-amd64/Packages' computed at 2020-10-29-13:25:03
14:25:03 --------------------------------------------------------------------------------
14:25:03 ## Package Updates for eloquent
14:25:03 
14:25:03 ### Added Packages [3]:
14:25:03 
14:25:03  * ros-eloquent-ament-cmake-core: 0.8.2-1
14:25:03  * ros-eloquent-ament-package: 0.8.9-1
14:25:03  * ros-eloquent-ros-workspace: 1.0.1-1
14:25:03 
14:25:03 ### Updated Packages [0]:
14:25:03 
14:25:03 
14:25:03 ### Removed Packages [0]:
14:25:03 
14:25:03 
14:25:03 Thanks to all ROS maintainers who make packages available to the ROS community. The above list of packages was made possible by the work of the following maintainers: 
14:25:03 
14:25:03  * Dirk Thomas
14:25:03  * Steven! Ragnarök
14:25:03 
```

Tested here: [![Build Status](https://build.test.ros2.org/buildStatus/icon?job=Erel_sync-packages-to-testing_bionic_amd64&build=7)](https://build.test.ros2.org/job/Erel_sync-packages-to-testing_bionic_amd64/7/)
