### PR TITLE
Use NamedTemporaryFile to avoid problems with PackageFile+StringIO in python3

### DIFF
--- a/scripts/diff_packages.py
+++ b/scripts/diff_packages.py
@@ -33,12 +33,12 @@ def main():
     )
 
     try:
-        pf_old = diff_repos.get_packagefile_from_url(target_url, name='old')
+        pf_old = diff_repos.get_packagefile_from_url(target_url)
     except RuntimeError as ex:
         parser.error("%s" % ex)
 
     try:
-        pf_new = diff_repos.get_packagefile_from_url(upstream_url, name='new')
+        pf_new = diff_repos.get_packagefile_from_url(upstream_url)
     except RuntimeError as ex:
         parser.error("%s" % ex)
 

--- a/scripts/sync_ros_packages.py
+++ b/scripts/sync_ros_packages.py
@@ -109,12 +109,12 @@ for ubuntu_distro in distros:
             'main',
             package_architecture)
         try:
-            pf_old = diff_repos.get_packagefile_from_url(target_url, name='old')
+            pf_old = diff_repos.get_packagefile_from_url(target_url)
         except RuntimeError as ex:
             print("Exception: %s \n NOT Computing diff" % ex, file=sys.stderr)
             continue
         try:
-            pf_new = diff_repos.get_packagefile_from_url(upstream_url, name='new')
+            pf_new = diff_repos.get_packagefile_from_url(upstream_url)
         except RuntimeError as ex:
             print("Exception: %s \n NOT Computing diff" % ex, file=sys.stderr)
             continue

--- a/src/reprepro_updater/diff_repos.py
+++ b/src/reprepro_updater/diff_repos.py
@@ -55,7 +55,7 @@ def get_packagefile_from_url(url):
     try:
         with NamedTemporaryFile() as temp:
             urlretrieve(url, temp.name)
-            package_file = PackageFile('Packages')
+            package_file = PackageFile(temp.name)
     except URLError as ex:
         raise RuntimeError("Failed to load from url %s [%s]" % (url, ex))
 

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -8,7 +8,7 @@ def test_announcement():
         target_url = 'file://' + os.path.abspath(os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
             'test_data/Packages.target'))
-        pf_old = diff_repos.get_packagefile_from_url(target_url, name='old')
+        pf_old = diff_repos.get_packagefile_from_url(target_url)
     except RuntimeError:
         assert False
 
@@ -16,7 +16,7 @@ def test_announcement():
         upstream_url = 'file://' + os.path.abspath(os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
             'test_data/Packages.upstream'))
-        pf_new = diff_repos.get_packagefile_from_url(upstream_url, name='new')
+        pf_new = diff_repos.get_packagefile_from_url(upstream_url)
     except RuntimeError:
         assert False
 


### PR DESCRIPTION
`PackageFile` constructor:
```python
def __init__(self, name, file_obj=None, encoding="utf-8"):
        """Creates a new package file object.
         name - the name of the file the data comes from
         file_obj - an alternate data source; the default is to open the
                       file with the indicated name.
          """
           if file_obj is None:
               file_obj = open(name, 'rb')
```
and iter as:
```python
        def __iter__(self):
           line = self.file.readline().decode(self.encoding)
```
When using `StringIO` the readline returns `str` and the decode fails. When using real filesystem paths, the readline returns `bytes` and the thing seems to work fine.

Upstream code could be patched to work with `StringIO` I'll see if I have time to send a patch there.

Tested here:
[![Build Status](https://build.test.ros2.org/buildStatus/icon?job=Erel_sync-packages-to-testing_bionic_amd64&build=14)](https://build.test.ros2.org/job/Erel_sync-packages-to-testing_bionic_amd64/14/)