### PR TITLE
Handle differences between Python 2 and 3.

### DIFF
--- a/scripts/sync_ros_packages.py
+++ b/scripts/sync_ros_packages.py
@@ -124,7 +124,10 @@ for ubuntu_distro in distros:
               (target_url, upstream_url, dtime.isoformat('-')))
         announcement = diff_repos.compute_annoucement(options.rosdistro, pf_old, pf_new)
         print('-' * 80)
-        print(announcement.encode('utf-8'))
+        if sys.version_info[0] >= 3:
+            print(announcement)
+        else:
+            print(announcement.encode('utf-8'))
         print('-' * 80)
 
 # clean up first


### PR DESCRIPTION
For python3 encoding the string returns a bytes object rather than a
string rather than a correctly encoded string. The regression was introduced when the switch to python3 was completed with https://github.com/ros-infrastructure/ros_buildfarm/pull/842

Printed announcement before:

```
--------------------------------------------------------------------------------
09:46:10 b'## Package Updates for dashing\n\n### Added Packages [0]:\n\n\n### Updated Packages [0]:\n\n\n### Removed Packages [0]:\n\n\nThanks to all ROS maintainers who make packages available to the ROS community. The above list of packages was made possible by the work of the following maintainers: \n\n'
09:46:10 --------------------------------------------------------------------------------
```

and after
``` 
09:47:56 --------------------------------------------------------------------------------
09:47:56 ## Package Updates for dashing
09:47:56 
09:47:56 ### Added Packages [0]:
09:47:56 
09:47:56 
09:47:56 ### Updated Packages [0]:
09:47:56 
09:47:56 
09:47:56 ### Removed Packages [0]:
09:47:56 
09:47:56 
09:47:56 Thanks to all ROS maintainers who make packages available to the ROS community. The above list of packages was made possible by the work of the following maintainers: 
09:47:56 
09:47:56 
09:47:56 --------------------------------------------------------------------------------
```

closes #87 