### PR TITLE
Add the pyside2 source package to the import formula.

### DIFF
--- a/config/pyside2.prerelease.yaml
+++ b/config/pyside2.prerelease.yaml
@@ -3,4 +3,54 @@ method: http://ppa.launchpad.net/tully.foote/pyside2-reproduction/ubuntu/
 suites: [xenial]
 component: main
 architectures: [i386, amd64, armhf, arm64, source]
-filter_formula: Package (== pyside2) | Package (% python-pyside2*) | Package (% libpyside2*) | Package (% libpyside-py3-2*) | Package (== shiboken2) | Package (% libshiboken2* ) | Package (% libshiboken-py3-2*)
+filter_formula: "\
+((Package (= pyside2) |\
+Package (= libpyside-py3-2.0) |\
+Package (= libpyside2-dev) |\
+Package (= libpyside2.0) |\
+Package (= python-pyside2) |\
+Package (= python-pyside2-dbg) |\
+Package (= python-pyside2.qtconcurrent) |\
+Package (= python-pyside2.qtconcurrent-dbg) |\
+Package (= python-pyside2.qtcore) |\
+Package (= python-pyside2.qtcore-dbg) |\
+Package (= python-pyside2.qtgui) |\
+Package (= python-pyside2.qtgui-dbg) |\
+Package (= python-pyside2.qthelp) |\
+Package (= python-pyside2.qthelp-dbg) |\
+Package (= python-pyside2.qtnetwork) |\
+Package (= python-pyside2.qtnetwork-dbg) |\
+Package (= python-pyside2.qtprintsupport) |\
+Package (= python-pyside2.qtprintsupport-dbg) |\
+Package (= python-pyside2.qtqml) |\
+Package (= python-pyside2.qtqml-dbg) |\
+Package (= python-pyside2.qtquick) |\
+Package (= python-pyside2.qtquick-dbg) |\
+Package (= python-pyside2.qtquickwidgets) |\
+Package (= python-pyside2.qtquickwidgets-dbg) |\
+Package (= python-pyside2.qtscript) |\
+Package (= python-pyside2.qtscript-dbg) |\
+Package (= python-pyside2.qtsql) |\
+Package (= python-pyside2.qtsql-dbg) |\
+Package (= python-pyside2.qtsvg) |\
+Package (= python-pyside2.qtsvg-dbg) |\
+Package (= python-pyside2.qttest) |\
+Package (= python-pyside2.qttest-dbg) |\
+Package (= python-pyside2.qtuitools) |\
+Package (= python-pyside2.qtuitools-dbg) |\
+Package (= python-pyside2.qtwebkit) |\
+Package (= python-pyside2.qtwebkit-dbg) |\
+Package (= python-pyside2.qtwebkitwidgets) |\
+Package (= python-pyside2.qtwebkitwidgets-dbg) |\
+Package (= python-pyside2.qtwidgets) |\
+Package (= python-pyside2.qtwidgets-dbg) |\
+Package (= python-pyside2.qtx11extras) |\
+Package (= python-pyside2.qtx11extras-dbg) |\
+Package (= python-pyside2.qtxml)), \
+$Version (% 2.0.0+dev-0~201604151742~rev1858~pkg38~ubuntu16.04.1) |\
+((Package (= shiboken2) |\
+Package (= libshiboken-py3-2.0) |\
+Package (= libshiboken2-dev) |\
+Package (= libshiboken2.0)), \
+$Version (% 2.0.0.dev0-0~201604191548~rev1610~pkg23~ubuntu16.04.1))\
+"

--- a/config/pyside2.prerelease.yaml
+++ b/config/pyside2.prerelease.yaml
@@ -47,10 +47,10 @@ Package (= python-pyside2.qtwidgets-dbg) |\
 Package (= python-pyside2.qtx11extras) |\
 Package (= python-pyside2.qtx11extras-dbg) |\
 Package (= python-pyside2.qtxml)), \
-$Version (% 2.0.0+dev-0~201604151742~rev1858~pkg38~ubuntu16.04.1) |\
+$Version (% 2.0.0+dev1-1~202102130210~rev1858~pkg5~git131fdfd1~ubuntu16.04.1) |\
 ((Package (= shiboken2) |\
 Package (= libshiboken-py3-2.0) |\
 Package (= libshiboken2-dev) |\
 Package (= libshiboken2.0)), \
-$Version (% 2.0.0.dev0-0~201604191548~rev1610~pkg23~ubuntu16.04.1))\
+$Version (% 2.0.0.dev0-0~202102130129~rev1610~pkg5~ubuntu16.04.1))\
 "

--- a/config/pyside2.prerelease.yaml
+++ b/config/pyside2.prerelease.yaml
@@ -1,6 +1,6 @@
 name: pyside2
-method: http://ppa.launchpad.net/thopiekar/pyside-git/ubuntu/
-suites: [wily, xenial]
+method: http://ppa.launchpad.net/tully.foote/pyside2-reproduction/ubuntu/
+suites: [xenial]
 component: main
 architectures: [i386, amd64, armhf, arm64, source]
 filter_formula: Package (== pyside2) | Package (% python-pyside2*) | Package (% libpyside2*) | Package (% libpyside-py3-2*) | Package (== shiboken2) | Package (% libshiboken2* ) | Package (% libshiboken-py3-2*)

--- a/config/pyside2.prerelease.yaml
+++ b/config/pyside2.prerelease.yaml
@@ -46,7 +46,8 @@ Package (= python-pyside2.qtwidgets) |\
 Package (= python-pyside2.qtwidgets-dbg) |\
 Package (= python-pyside2.qtx11extras) |\
 Package (= python-pyside2.qtx11extras-dbg) |\
-Package (= python-pyside2.qtxml)), \
+Package (= python-pyside2.qtxml) \
+Package (= python-pyside2.qtxml-dbg)), \
 $Version (% 2.0.0+dev1-1~202102130210~rev1858~pkg5~git131fdfd1~ubuntu16.04.1) |\
 ((Package (= shiboken2) |\
 Package (= libshiboken-py3-2.0) |\

--- a/config/pyside2.prerelease.yaml
+++ b/config/pyside2.prerelease.yaml
@@ -3,4 +3,4 @@ method: http://ppa.launchpad.net/thopiekar/pyside-git/ubuntu/
 suites: [wily, xenial]
 component: main
 architectures: [i386, amd64, armhf, arm64, source]
-filter_formula: Package (% python-pyside2*) | Package (% libpyside2*) | Package (% libpyside-py3-2*) | Package (== shiboken2) | Package (% libshiboken2* ) | Package (% libshiboken-py3-2*)
+filter_formula: Package (== pyside2) | Package (% python-pyside2*) | Package (% libpyside2*) | Package (% libpyside-py3-2*) | Package (== shiboken2) | Package (% libshiboken2* ) | Package (% libshiboken-py3-2*)


### PR DESCRIPTION
Because the source package for the pyside2 collection is called simply `pyside2` it was not imported as was originally intended along with the rest of these packages. Because the source package for shiboken2 is called `shiboken2` that source package was successfully imported previously.

The version of pyside2 which was imported previously is no longer available in the linked PPA so this import should not be re-run unless the PPA is updated or an examination of the differences between the current ROS and PPA packages is performed.