### PR TITLE
Add ceres-solver source package import formula (Xenial)

### DIFF
--- a/config/ceres_xenial.yaml
+++ b/config/ceres_xenial.yaml
@@ -7,6 +7,6 @@ filter_formula: "\
 ((Package (= ceres-solver) |\
 Package (= libceres-dev) |\
 Package (= libceres1) |\
-Package (= ceres-solver-doc)), |\
+Package (= ceres-solver-doc)), \
 $Version (% libceres1_1.12.0+dfsg0-5))\
 "

--- a/config/ceres_xenial.yaml
+++ b/config/ceres_xenial.yaml
@@ -8,5 +8,5 @@ filter_formula: "\
 Package (= libceres-dev) |\
 Package (= libceres1) |\
 Package (= ceres-solver-doc)), \
-$Version (% libceres1_1.12.0+dfsg0-5))\
+$Version (% 1.12.0+dfsg0-5))\
 "

--- a/config/ceres_xenial.yaml
+++ b/config/ceres_xenial.yaml
@@ -8,5 +8,5 @@ filter_formula: "\
 Package (= libceres-dev) |\
 Package (= libceres1) |\
 Package (= ceres-solver-doc)), |\
-$Version (% libceres1_1.12.0+dfsg0-5))|\
+$Version (% libceres1_1.12.0+dfsg0-5))\
 "

--- a/config/ceres_xenial.yaml
+++ b/config/ceres_xenial.yaml
@@ -1,0 +1,12 @@
+name: ceres_xenial
+method: http://ppa.launchpad.net/j-rivero/reproduce-ceres-xenial/ubuntu
+suites: [xenial]
+component: main
+architectures: [i386, amd64, armhf, arm64, source]
+filter_formula: "\
+((Package (= ceres-solver) |\
+Package (= libceres-dev) |\
+Package (= libceres1) |\
+Package (= ceres-solver-doc)), |\
+$Version (% libceres1_1.12.0+dfsg0-5))|\
+"


### PR DESCRIPTION
The formula will import the ceres-solver packages (including source package) corresponding to the rebuild effort of the same source used in http://repos.ros.org/repos/ros_bootstrap/pool/main/c/ceres-solver/ to recreate the source package file for version `1.12.0+dfsg0-1~ubuntu16.04.1`, revision has changed to `libceres1_1.12.0+dfsg0-5_amd64.deb `, source code should be the same.

I ran the debdiff tool on both packages and try to run auto-abi checker: https://github.com/j-rivero/bootstrap_abi_checking/runs/1990550634?check_suite_focus=true

debdiff + abipkgdiff tools are happy, reporting:
```
2021-02-26T20:39:22.4052848Z #17 0.357 ************************
2021-02-26T20:39:22.4053990Z #17 0.357 COMPARING DEBDIFF bootstrap/libceres1_1.12.0+dfsg0-1~ubuntu16.04.1_amd64.deb -- prerelease/libceres1_1.12.0+dfsg0-5_amd64.deb 
2021-02-26T20:39:22.4054766Z #17 0.357 
2021-02-26T20:39:22.5552794Z #17 0.560 File lists identical (after any substitutions)
2021-02-26T20:39:22.5553552Z #17 0.574 
2021-02-26T20:39:22.5554055Z #17 0.574 Control files: lines which differ (wdiff format)
2021-02-26T20:39:22.5555257Z #17 0.574 ------------------------------------------------
2021-02-26T20:39:22.5556010Z #17 0.574 Installed-Size: [-2997-] {+3000+}
2021-02-26T20:39:22.5556778Z #17 0.574 Version: [-1.12.0+dfsg0-1~ubuntu16.04.1-] {+1.12.0+dfsg0-5+}
2021-02-26T20:39:22.6976646Z #17 0.796 File lists identical (after any substitutions)
2021-02-26T20:39:22.7981436Z #17 0.796 
2021-02-26T20:39:22.7981912Z #17 0.796 ************************
2021-02-26T20:39:22.7983642Z #17 0.796 COMPARING ABIPKGDIFF bootstrap/libceres1_1.12.0+dfsg0-1~ubuntu16.04.1_amd64.deb -- prerelease/libceres1_1.12.0+dfsg0-5_amd64.deb 
2021-02-26T20:39:22.7984473Z #17 0.796 
2021-02-26T20:39:22.7987223Z #17 0.800 abipkgdiff: Extracting package /tmp/bootstrap/libceres1_1.12.0+dfsg0-1~ubuntu16.04.1_amd64.deb to /tmp/libabigail-tmp-dir-BPU52b/package1 ...abipkgdiffabipkgdiff: command test -d /tmp/libabigail-tmp-dir-BPU52b/package1 && rm -rf /tmp/libabigail-tmp-dir-BPU52b/package1 FAILED
2021-02-26T20:39:22.7991297Z #17 0.802 : Extracting package /tmp/prerelease/libceres1_1.12.0+dfsg0-5_amd64.deb to /tmp/libabigail-tmp-dir-BPU52b/package2 ...abipkgdiff: command test -d /tmp/libabigail-tmp-dir-BPU52b/package2 && rm -rf /tmp/libabigail-tmp-dir-BPU52b/package2 FAILED
2021-02-26T20:39:22.7993025Z #17 0.883 abipkgdiff:  DONE
2021-02-26T20:39:22.7994829Z #17 0.883 abipkgdiff: Analyzing the content of package /tmp/bootstrap/libceres1_1.12.0+dfsg0-1~ubuntu16.04.1_amd64.deb extracted to /tmp/libabigail-tmp-dir-BPU52b/package1 ...abipkgdiff: abipkgdiff:  DONE
2021-02-26T20:39:22.7997361Z #17 0.884  DONE
2021-02-26T20:39:22.7999141Z #17 0.884 abipkgdiff: Analyzing the content of package /tmp/prerelease/libceres1_1.12.0+dfsg0-5_amd64.deb extracted to /tmp/libabigail-tmp-dir-BPU52b/package2 ...abipkgdiff:  DONE
2021-02-26T20:39:22.8001485Z #17 0.885 abipkgdiff: Comparing the ABIs of file /tmp/libabigail-tmp-dir-BPU52b/package1/usr/lib/libceres.so.1.12.0 and /tmp/libabigail-tmp-dir-BPU52b/package2/usr/lib/libceres.so.1.12.0...
2021-02-26T20:39:22.8003386Z #17 0.887 abipkgdiff:   Reading file /tmp/libabigail-tmp-dir-BPU52b/package1/usr/lib/libceres.so.1.12.0 ...
2021-02-26T20:39:22.9481519Z #17 0.897 abipkgdiff:  DONE reading file /tmp/libabigail-tmp-dir-BPU52b/package1/usr/lib/libceres.so.1.12.0 ...
2021-02-26T20:39:22.9483103Z #17 0.898 abipkgdiff:   Reading file /tmp/libabigail-tmp-dir-BPU52b/package2/usr/lib/libceres.so.1.12.0 ...
2021-02-26T20:39:22.9484845Z #17 0.908 abipkgdiff:  DONE reading file /tmp/libabigail-tmp-dir-BPU52b/package2/usr/lib/libceres.so.1.12.0 ...
2021-02-26T20:39:22.9485782Z #17 0.910 abipkgdiff:   Comparing the ABIs of: 
2021-02-26T20:39:22.9486810Z #17 0.910     /tmp/libabigail-tmp-dir-BPU52b/package1/usr/lib/libceres.so.1.12.0
2021-02-26T20:39:22.9488070Z #17 0.911     /tmp/libabigail-tmp-dir-BPU52b/package2/usr/lib/libceres.so.1.12.0
2021-02-26T20:39:22.9489968Z #17 0.921 abipkgdiff: Comparing the ABIs of file /tmp/libabigail-tmp-dir-BPU52b/package1/usr/lib/libceres.so.1.12.0 and /tmp/libabigail-tmp-dir-BPU52b/package2/usr/lib/libceres.so.1.12.0 is DONE
2021-02-26T20:39:22.9492240Z #17 0.925 abipkgdiff: Erasing temporary extraction directory /tmp/libabigail-tmp-dir-BPU52b/package1 ...abipkgdiff:  DONE
2021-02-26T20:39:22.9493657Z #17 0.928 abipkgdiff: Erasing temporary extraction directory /tmp/libabigail-tmp-dir-BPU52b/package2 ...abipkgdiff:  DONE
2021-02-26T20:39:22.9495039Z #17 0.930 abipkgdiff: Erasing temporary extraction parent directory /tmp/libabigail-tmp-dir-BPU52b ...abipkgdiff: DONE
2021-02-26T20:39:22.9497828Z #17 0.935 
2021-02-26T20:39:22.9498139Z #17 0.935 ************************
2021-02-26T20:39:22.9499205Z #17 0.935 COMPARING DEBDIFF bootstrap/ceres-solver-doc_1.12.0+dfsg0-1_all.deb -- prerelease/ceres-solver-doc_1.12.0+dfsg0-5_all.deb 
2021-02-26T20:39:22.9500159Z #17 0.935 
2021-02-26T20:39:23.2480639Z #17 1.274 File lists identical (after any substitutions)
2021-02-26T20:39:23.2481326Z #17 1.286 
2021-02-26T20:39:23.2481906Z #17 1.286 Control files: lines which differ (wdiff format)
2021-02-26T20:39:23.2483160Z #17 1.286 ------------------------------------------------
2021-02-26T20:39:23.2483868Z #17 1.286 Version: [-1.12.0+dfsg0-1-] {+1.12.0+dfsg0-5+}
2021-02-26T20:39:23.5477279Z #17 1.646 File lists identical (after any substitutions)
2021-02-26T20:39:23.6974771Z #17 1.647 
2021-02-26T20:39:23.6975148Z #17 1.647 ************************
2021-02-26T20:39:23.6976933Z #17 1.647 COMPARING ABIPKGDIFF bootstrap/ceres-solver-doc_1.12.0+dfsg0-1_all.deb -- prerelease/ceres-solver-doc_1.12.0+dfsg0-5_all.deb 
2021-02-26T20:39:23.6977754Z #17 1.647 
2021-02-26T20:39:23.6980598Z #17 1.650 abipkgdiff: Extracting package /tmp/bootstrap/ceres-solver-doc_1.12.0+dfsg0-1_all.deb to /tmp/libabigail-tmp-dir-NtTpc1/package1 ...abipkgdiff: Extracting package /tmp/prerelease/ceres-solver-doc_1.12.0+dfsg0-5_all.deb to /tmp/libabigail-tmp-dir-NtTpc1/package2 ...abipkgdiff: command test -d /tmp/libabigail-tmp-dir-NtTpc1/package1 && rm -rf /tmp/libabigail-tmp-dir-NtTpc1/package1 FAILED
2021-02-26T20:39:23.6983681Z #17 1.653 abipkgdiff: command test -d /tmp/libabigail-tmp-dir-NtTpc1/package2 && rm -rf /tmp/libabigail-tmp-dir-NtTpc1/package2 FAILED
2021-02-26T20:39:23.8475511Z #17 1.811 abipkgdiff:  DONE
2021-02-26T20:39:23.8477564Z #17 1.812 abipkgdiff: Analyzing the content of package /tmp/prerelease/ceres-solver-doc_1.12.0+dfsg0-5_all.deb extracted to /tmp/libabigail-tmp-dir-NtTpc1/package2 ...abipkgdiff:  DONE
2021-02-26T20:39:23.8478582Z #17 1.823 abipkgdiff:  DONE
2021-02-26T20:39:23.8480086Z #17 1.823 abipkgdiff: Analyzing the content of package /tmp/bootstrap/ceres-solver-doc_1.12.0+dfsg0-1_all.deb extracted to /tmp/libabigail-tmp-dir-NtTpc1/package1 ...abipkgdiff:  DONE
2021-02-26T20:39:23.8481776Z #17 1.827 abipkgdiff: Erasing temporary extraction directory /tmp/libabigail-tmp-dir-NtTpc1/package1 ...abipkgdiff:  DONE
2021-02-26T20:39:23.8483544Z #17 1.832 abipkgdiff: Erasing temporary extraction directory /tmp/libabigail-tmp-dir-NtTpc1/package2 ...abipkgdiff:  DONE
2021-02-26T20:39:23.8485263Z #17 1.837 abipkgdiff: Erasing temporary extraction parent directory /tmp/libabigail-tmp-dir-NtTpc1 ...abipkgdiff: DONE
2021-02-26T20:39:23.8488144Z #17 1.843 
2021-02-26T20:39:23.8488425Z #17 1.843 ************************
2021-02-26T20:39:23.8489395Z #17 1.843 COMPARING DEBDIFF bootstrap/libceres-dev_1.12.0+dfsg0-1~ubuntu16.04.1_amd64.deb -- prerelease/libceres-dev_1.12.0+dfsg0-5_amd64.deb 
2021-02-26T20:39:23.8490125Z #17 1.843 
2021-02-26T20:39:24.1478223Z #17 2.131 File lists identical (after any substitutions)
2021-02-26T20:39:24.1478739Z #17 2.144 
2021-02-26T20:39:24.1479153Z #17 2.144 Control files: lines which differ (wdiff format)
2021-02-26T20:39:24.1480269Z #17 2.144 ------------------------------------------------
2021-02-26T20:39:24.1481503Z #17 2.144 Depends: libceres1 (= [-1.12.0+dfsg0-1~ubuntu16.04.1),-] {+1.12.0+dfsg0-5),+} libgoogle-glog-dev, libgflags-dev, libeigen3-dev (>= 3.2.1), libsuitesparse-dev (>= 1:4.4.3)
2021-02-26T20:39:24.1482577Z #17 2.144 Installed-Size: [-9849-] {+9854+}
2021-02-26T20:39:24.1483380Z #17 2.144 Version: [-1.12.0+dfsg0-1~ubuntu16.04.1-] {+1.12.0+dfsg0-5+}
2021-02-26T20:39:24.4480824Z #17 2.463 File lists identical (after any substitutions)
2021-02-26T20:39:24.4481347Z #17 2.463 
2021-02-26T20:39:24.4481657Z #17 2.463 ************************
2021-02-26T20:39:24.4483468Z #17 2.463 COMPARING ABIPKGDIFF bootstrap/libceres-dev_1.12.0+dfsg0-1~ubuntu16.04.1_amd64.deb -- prerelease/libceres-dev_1.12.0+dfsg0-5_amd64.deb 
2021-02-26T20:39:24.4484659Z #17 2.463 
2021-02-26T20:39:24.4487375Z #17 2.466 abipkgdiff: Extracting package /tmp/bootstrap/libceres-dev_1.12.0+dfsg0-1~ubuntu16.04.1_amd64.deb to /tmp/libabigail-tmp-dir-6vUeHT/package1 ...abipkgdiff: Extracting package /tmp/prerelease/libceres-dev_1.12.0+dfsg0-5_amd64.deb to /tmp/libabigail-tmp-dir-6vUeHT/package2 ...abipkgdiff: command test -d /tmp/libabigail-tmp-dir-6vUeHT/package1 && rm -rf /tmp/libabigail-tmp-dir-6vUeHT/package1 FAILED
2021-02-26T20:39:24.4490689Z #17 2.468 abipkgdiff: command test -d /tmp/libabigail-tmp-dir-6vUeHT/package2 && rm -rf /tmp/libabigail-tmp-dir-6vUeHT/package2 FAILED
2021-02-26T20:39:24.5573211Z #17 2.601 abipkgdiff:  DONE
2021-02-26T20:39:24.5575181Z #17 2.602 abipkgdiff: Analyzing the content of package /tmp/prerelease/libceres-dev_1.12.0+dfsg0-5_amd64.deb extracted to /tmp/libabigail-tmp-dir-6vUeHT/package2 ...abipkgdiff:  DONE
2021-02-26T20:39:24.5576709Z #17 2.606 abipkgdiff:  DONE
2021-02-26T20:39:24.5578075Z #17 2.606 abipkgdiff: Analyzing the content of package /tmp/bootstrap/libceres-dev_1.12.0+dfsg0-1~ubuntu16.04.1_amd64.deb extracted to /tmp/libabigail-tmp-dir-6vUeHT/package1 ...abipkgdiff:  DONE
2021-02-26T20:39:24.5579706Z #17 2.608 abipkgdiff: Erasing temporary extraction directory /tmp/libabigail-tmp-dir-6vUeHT/package1 ...abipkgdiff:  DONE
2021-02-26T20:39:24.5581133Z #17 2.612 abipkgdiff: Erasing temporary extraction directory /tmp/libabigail-tmp-dir-6vUeHT/package2 ...abipkgdiff:  DONE
2021-02-26T20:39:24.5582520Z #17 2.624 abipkgdiff: Erasing temporary extraction parent directory /tmp/libabigail-tmp-dir-6vUeHT ...abipkgdiff: DONE
2021-02-26T20:39:24.5584607Z #17 DONE 2.7s
```
