### PR TITLE
Converge lark-parser packages on a single orig.tar for 0.7.2

### DIFF
--- a/config/lark-parser_stretch_buster.yaml
+++ b/config/lark-parser_stretch_buster.yaml
@@ -1,0 +1,12 @@
+name: lark-parser_stretch_buster
+method: http://packages.osrfoundation.org/gazebo/debian-testing
+suites: [buster, stretch]
+component: main
+# python packages only, all arches supported
+architectures: [amd64, arm64, armhf source]
+filter_formula: "\
+((Package (% =lark-parser) |\
+  Package (% =python3-lark-parser) |\
+  Package (% =python3-lark-parser-doc)),
+  $Version (% 0.7.2-3osrf~* ))\
+"

--- a/config/lark-parser_xenial.yaml
+++ b/config/lark-parser_xenial.yaml
@@ -1,6 +1,6 @@
 name: lark-parser_xenial
-method: http://packages.osrfoundation.org/gazebo/ubuntu-prerelease
-suites: [xenial]
+method: http://packages.osrfoundation.org/gazebo/ubuntu-testing
+suites: [bionic, buster, stretch, xenial]
 component: main
 # python packages only, all arches supported
 architectures: [amd64, arm64, armhf source]
@@ -8,5 +8,5 @@ filter_formula: "\
 ((Package (% =lark-parser) |\
   Package (% =python3-lark-parser) |\
   Package (% =python3-lark-parser-doc)),
-  $Version (% 0.7.2-2osrf~xenial))\
+  $Version (% 0.7.2-3osrf~* ))\
 "

--- a/config/lark-parser_xenial_bionic.yaml
+++ b/config/lark-parser_xenial_bionic.yaml
@@ -1,6 +1,6 @@
-name: lark-parser_xenial
+name: lark-parser_xenial_bionic
 method: http://packages.osrfoundation.org/gazebo/ubuntu-testing
-suites: [bionic, buster, stretch, xenial]
+suites: [bionic, xenial]
 component: main
 # python packages only, all arches supported
 architectures: [amd64, arm64, armhf source]


### PR DESCRIPTION
When importing the new source package for Xenial it introduced a conflict with the already-present source package orig.tar files so we've updated all of them to use the same one.