### PR TITLE
Update gui3 and msgs5 in ignition_citadel_gazebo11_ubuntu_focal to latest version

### DIFF
--- a/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
+++ b/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
@@ -33,7 +33,7 @@ Package (% =libignition-gazebo3-plugins)), \
 $Version (% 3.8.0-1~focal)) |\
 ((Package (% =ignition-gui3) |\
 Package (% libignition-gui3) |\
-Package (% libignition-gui3-dev)), |\
+Package (% libignition-gui3-dev)), \
 $Version (% 3.5.0-1~focal)) |\
 ((Package (% =ignition-launch2) |\
 Package (% =libignition-launch2) |\
@@ -43,7 +43,7 @@ $Version (% 2.2.1-1~focal)) |\
 ((Package (% =ignition-msgs5) |\
 Package (% =libignition-msgs5) |\
 Package (% =libignition-msgs5-dev) |\
-Package (% =libignition-msgs5-dbg)), |\
+Package (% =libignition-msgs5-dbg)), \
 $Version (% 5.7.0-1~focal)) |\
 (Package (% =ignition-physics2), $Version (% 2.3.0-1~focal)) |\
 (Package (% =ignition-plugin), $Version (% 1.1.0-1~focal)) |\

--- a/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
+++ b/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
@@ -31,13 +31,20 @@ Package (% =libignition-gazebo3) |\
 Package (% =libignition-gazebo3-dev) |\
 Package (% =libignition-gazebo3-plugins)), \
 $Version (% 3.8.0-1~focal)) |\
-(Package (% =ignition-gui3), $Version (% 3.4.0-1~focal)) |\
+((Package (% =ignition-gui3) |\
+Package (% libignition-gui3) |\
+Package (% libignition-gui3-dev)), |\
+$Version (% 3.5.0-1~focal)) |\
 ((Package (% =ignition-launch2) |\
 Package (% =libignition-launch2) |\
 Package (% =libignition-launch2-dev)), \
 $Version (% 2.2.1-1~focal)) |\
 (Package (% =ignition-math6), $Version (% 6.7.0-1~focal)) |\
-(Package (% =ignition-msgs5), $Version (% 5.6.0-1~focal)) |\
+((Package (% =ignition-msgs5) |\
+Package (% =libignition-msgs5) |\
+Package (% =libignition-msgs5-dev) |\
+Package (% =libignition-msgs5-dbg)), |\
+$Version (% 5.7.0-1~focal)) |\
 (Package (% =ignition-physics2), $Version (% 2.3.0-1~focal)) |\
 (Package (% =ignition-plugin), $Version (% 1.1.0-1~focal)) |\
 ((Package (% =ignition-rendering3) |\


### PR DESCRIPTION
New versions of ign-gui3 and ign-msgs5 appeared while we were processing #102 . This PR list and updates to latest version them.