### PR TITLE
Ignition: fix Focal

### DIFF
--- a/config/ignition_citadel_gazebo11_debian_buster.yaml
+++ b/config/ignition_citadel_gazebo11_debian_buster.yaml
@@ -1,4 +1,4 @@
-name: ignition_citadel_gazebo11_debian_buster.yaml
+name: ignition_citadel_gazebo11_debian_buster
 method: http://packages.osrfoundation.org/gazebo/debian-stable
 suites: [buster]
 component: main

--- a/config/ignition_citadel_gazebo11_debian_buster.yaml
+++ b/config/ignition_citadel_gazebo11_debian_buster.yaml
@@ -10,10 +10,10 @@ Package (% =gazebo11-dbg) |\
 Package (% =gazebo11-doc) |\
 Package (% =libgazebo11) |\
 Package (% =libgazebo11-dev)), \
-$Version (% 11.5.0-1~buster)) |\
+$Version (% 11.5.0-1~*)) |\
 ((Package (% =ignition-cmake2) |\
 Package (% =libignition-cmake2-dev)) |\
-$Version (% 2.7.0-1~buster)) |\
+$Version (% 2.7.0-1~*)) |\
 (Package (% =ignition-citadel), $Version (% 1.0.0*))|\
 ((Package (% =ignition-common3) |\
 Package (% =libignition-common3) |\
@@ -27,32 +27,32 @@ Package (% =libignition-common3-graphics) |\
 Package (% =libignition-common3-graphics-dev) |\
 Package (% =libignition-common3-profiler) |\
 Package (% =libignition-common3-profiler-dev)), \
-$Version (% 3.12.0-1~buster)) |\
-(Package (% =ignition-fuel-tools4), $Version (% 4.3.0-1~buster)) |\
+$Version (% 3.12.0-1~*)) |\
+(Package (% =ignition-fuel-tools4), $Version (% 4.3.0-1~*)) |\
 ((Package (% =ignition-gazebo3) |\
 Package (% =libignition-gazebo3) |\
 Package (% =libignition-gazebo3-dev) |\
 Package (% =libignition-gazebo3-plugins)), \
-$Version (% 3.8.0-1~buster)) |\
+$Version (% 3.8.0-1~*)) |\
 ((Package (% =ignition-gui3) |\
 Package (% =libignition-gui3) |\
 Package (% =libignition-gui3-dev)), \
-$Version (% 3.5.1-1~buster)) |\
+$Version (% 3.5.1-1~*)) |\
 ((Package (% =ignition-launch2) |\
 Package (% =libignition-launch2) |\
 Package (% =libignition-launch2-dev)), \
-$Version (% 2.2.1-1~buster)) |\
+$Version (% 2.2.1-1~*)) |\
 ((Package (% =ignition-math6) |\
 Package (% =libignition-math6) |\
 Package (% =libignition-math6-dbg) |\
 Package (% =libignition-math6-dev) |\
 Package (% =libignition-math6-eigen3-dev)), \
-$Version (% 6.8.0-1~buster)) |\
+$Version (% 6.8.0-1~*)) |\
 ((Package (% =ignition-msgs5) |\
 Package (% =libignition-msgs5) |\
 Package (% =libignition-msgs5-dev) |\
 Package (% =libignition-msgs5-dbg)), \
-$Version (% 5.7.0-1~buster)) |\
+$Version (% 5.7.0-1~*)) |\
 ((Package (% =ignition-physics2) |\
 Package (% =libignition-physics2) |\
 Package (% =libignition-physics2-core-dev) |\
@@ -65,11 +65,11 @@ Package (% =libignition-physics2-tpe) |\
 Package (% =libignition-physics2-tpe-dev) |\
 Package (% =libignition-physics2-tpelib) |\
 Package (% =libignition-physics2-tpelib-dev)), \
-$Version (% 2.4.0-1~buster)) |\
+$Version (% 2.4.0-1~*)) |\
 ((Package (% =ignition-plugin) |\
 Package (% =libignition-plugin) |\
 Package (% =libignition-plugin-dev)), \
-$Version (% 1.2.0-1~buster)) |\
+$Version (% 1.2.0-1~*)) |\
 ((Package (% =ignition-rendering3) |\
 Package (% =libignition-rendering3) |\
 Package (% =libignition-rendering3-core-dev) |\
@@ -78,7 +78,7 @@ Package (% =libignition-rendering3-ogre1) |\
 Package (% =libignition-rendering3-ogre1-dev) |\
 Package (% =libignition-rendering3-ogre2) |\
 Package (% =libignition-rendering3-ogre2-dev)), \
-$Version (% 3.4.0-1~buster)) |\
+$Version (% 3.4.0-1~*)) |\
 ((Package (% =ignition-sensors3) |\
 Package (% =libignition-sensors3) |\
 Package (% =libignition-sensors3-air-pressure) |\
@@ -107,7 +107,7 @@ Package (% =libignition-sensors3-rgbd-camera) |\
 Package (% =libignition-sensors3-rgbd-camera-dev) |\
 Package (% =libignition-sensors3-thermal-camera) |\
 Package (% =libignition-sensors3-thermal-camera-dev)), \
-$Version (% 3.2.0-1~buster)) |\
+$Version (% 3.2.0-1~*)) |\
 ((Package (% =ignition-transport8) |\
 Package (% =libignition-transport8) |\
 Package (% =libignition-transport8-core-dev) |\
@@ -115,19 +115,19 @@ Package (% =libignition-transport8-dbg) |\
 Package (% =libignition-transport8-dev) |\
 Package (% =libignition-transport8-log) |\
 Package (% =libignition-transport8-log-dev)), \
-$Version (% 8.2.0-1~buster)) |\
+$Version (% 8.2.0-1~*)) |\
 ((Package (% =ignition-tools) |\
 Package (% =libignition-tools-dev)), \
-$Version (% 1.2.0-1~buster)) |\
+$Version (% 1.2.0-1~*)) |\
 ((Package (% =ogre-2.1) |\
 Package (% =libogre-2.1) |\
 Package (% =libogre-2.1-dev)),
-$Version (% 2.0.9999~20180616~06a386f-3osrf~buster)) |\
+$Version (% 2.0.9999~20180616~06a386f-3osrf~*)) |\
 ((Package (% =sdformat9) |\
 Package (% =libsdformat9) |\
 Package (% =libsdformat9-dbg) |\
 Package (% =libsdformat9-dev) |\
 Package (% =sdformat9-doc) |\
 Package (% =sdformat9-sdf)), \
-$Version (% 9.5.0-1~buster)) \
+$Version (% 9.5.0-1~*)) \
 "

--- a/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
+++ b/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
@@ -28,7 +28,10 @@ Package (% =libignition-common3-graphics-dev) |\
 Package (% =libignition-common3-profiler) |\
 Package (% =libignition-common3-profiler-dev)), \
 $Version (% 3.12.0-1~*)) |\
-(Package (% =ignition-fuel-tools4), $Version (% 4.3.0-1~*)) |\
+((Package (% =ignition-fuel-tools4) |\
+Package (% =libignition-fuel-tools4) |\
+Package (% =libignition-fuel-tools4-dev)), \
+$Version (% 4.3.0-1~*)) |\
 ((Package (% =ignition-gazebo3) |\
 Package (% =libignition-gazebo3) |\
 Package (% =libignition-gazebo3-dev) |\

--- a/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
+++ b/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
@@ -10,10 +10,13 @@ Package (% =gazebo11-dbg) |\
 Package (% =gazebo11-doc) |\
 Package (% =libgazebo11) |\
 Package (% =libgazebo11-dev)), \
-$Version (% 11.5.0-1~focal)) |\
-(Package (% =ignition-cmake2), $Version (% 2.7.0-1~focal)) |\
-(Package (% =ignition-common3), $Version (% 3.12.0-1~focal)) |\
-((Package (% =libignition-common3) |\
+$Version (% 11.5.0-1~*)) |\
+((Package (% =ignition-cmake2) |\
+Package (% =libignition-cmake2-dev)) |\
+$Version (% 2.7.0-1~*)) |\
+(Package (% =ignition-citadel), $Version (% 1.0.0*))|\
+((Package (% =ignition-common3) |\
+Package (% =libignition-common3) |\
 Package (% =libignition-common3-av) |\
 Package (% =libignition-common3-av-dev) |\
 Package (% =libignition-common3-core-dev) |\
@@ -24,29 +27,49 @@ Package (% =libignition-common3-graphics) |\
 Package (% =libignition-common3-graphics-dev) |\
 Package (% =libignition-common3-profiler) |\
 Package (% =libignition-common3-profiler-dev)), \
-$Version (% 3.12.0-1~focal)) |\
-(Package (% =ignition-fuel-tools4), $Version (% 4.3.0-1~focal)) |\
+$Version (% 3.12.0-1~*)) |\
+(Package (% =ignition-fuel-tools4), $Version (% 4.3.0-1~*)) |\
 ((Package (% =ignition-gazebo3) |\
 Package (% =libignition-gazebo3) |\
 Package (% =libignition-gazebo3-dev) |\
 Package (% =libignition-gazebo3-plugins)), \
-$Version (% 3.8.0-1~focal)) |\
+$Version (% 3.8.0-1~*)) |\
 ((Package (% =ignition-gui3) |\
-Package (% libignition-gui3) |\
-Package (% libignition-gui3-dev)), \
-$Version (% 3.5.1-1~focal)) |\
+Package (% =libignition-gui3) |\
+Package (% =libignition-gui3-dev)), \
+$Version (% 3.5.1-1~*)) |\
 ((Package (% =ignition-launch2) |\
 Package (% =libignition-launch2) |\
 Package (% =libignition-launch2-dev)), \
-$Version (% 2.2.1-1~focal)) |\
-(Package (% =ignition-math6), $Version (% 6.8.0-1~focal)) |\
+$Version (% 2.2.1-1~*)) |\
+((Package (% =ignition-math6) |\
+Package (% =libignition-math6) |\
+Package (% =libignition-math6-dbg) |\
+Package (% =libignition-math6-dev) |\
+Package (% =libignition-math6-eigen3-dev)), \
+$Version (% 6.8.0-1~*)) |\
 ((Package (% =ignition-msgs5) |\
 Package (% =libignition-msgs5) |\
 Package (% =libignition-msgs5-dev) |\
 Package (% =libignition-msgs5-dbg)), \
-$Version (% 5.7.0-1~focal)) |\
-(Package (% =ignition-physics2), $Version (% 2.4.0-1~focal)) |\
-(Package (% =ignition-plugin), $Version (% 1.2.0-1~focal)) |\
+$Version (% 5.7.0-1~*)) |\
+((Package (% =ignition-physics2) |\
+Package (% =libignition-physics2) |\
+Package (% =libignition-physics2-core-dev) |\
+Package (% =libignition-physics2-dartsim) |\
+Package (% =libignition-physics2-dartsim-dev) |\
+Package (% =libignition-physics2-dev) |\
+Package (% =libignition-physics2-mesh-dev) |\
+Package (% =libignition-physics2-sdf-dev) |\
+Package (% =libignition-physics2-tpe) |\
+Package (% =libignition-physics2-tpe-dev) |\
+Package (% =libignition-physics2-tpelib) |\
+Package (% =libignition-physics2-tpelib-dev)), \
+$Version (% 2.4.0-1~*)) |\
+((Package (% =ignition-plugin) |\
+Package (% =libignition-plugin) |\
+Package (% =libignition-plugin-dev)), \
+$Version (% 1.2.0-1~*)) |\
 ((Package (% =ignition-rendering3) |\
 Package (% =libignition-rendering3) |\
 Package (% =libignition-rendering3-core-dev) |\
@@ -55,7 +78,7 @@ Package (% =libignition-rendering3-ogre1) |\
 Package (% =libignition-rendering3-ogre1-dev) |\
 Package (% =libignition-rendering3-ogre2) |\
 Package (% =libignition-rendering3-ogre2-dev)), \
-$Version (% 3.4.0-1~focal)) |\
+$Version (% 3.4.0-1~*)) |\
 ((Package (% =ignition-sensors3) |\
 Package (% =libignition-sensors3) |\
 Package (% =libignition-sensors3-air-pressure) |\
@@ -84,17 +107,27 @@ Package (% =libignition-sensors3-rgbd-camera) |\
 Package (% =libignition-sensors3-rgbd-camera-dev) |\
 Package (% =libignition-sensors3-thermal-camera) |\
 Package (% =libignition-sensors3-thermal-camera-dev)), \
-$Version (% 3.2.0-1~focal)) |\
-(Package (% =ignition-transport8), $Version (% 8.2.0-1~focal)) |\
+$Version (% 3.2.0-1~*)) |\
+((Package (% =ignition-transport8) |\
+Package (% =libignition-transport8) |\
+Package (% =libignition-transport8-core-dev) |\
+Package (% =libignition-transport8-dbg) |\
+Package (% =libignition-transport8-dev) |\
+Package (% =libignition-transport8-log) |\
+Package (% =libignition-transport8-log-dev)), \
+$Version (% 8.2.0-1~*)) |\
+((Package (% =ignition-tools) |\
+Package (% =libignition-tools-dev)), \
+$Version (% 1.2.0-1~*)) |\
 ((Package (% =ogre-2.1) |\
 Package (% =libogre-2.1) |\
 Package (% =libogre-2.1-dev)),
-$Version (% 2.0.9999~20180616~06a386f-3osrf~focal)) |\
+$Version (% 2.0.9999~20180616~06a386f-3osrf~*)) |\
 ((Package (% =sdformat9) |\
 Package (% =libsdformat9) |\
 Package (% =libsdformat9-dbg) |\
 Package (% =libsdformat9-dev) |\
 Package (% =sdformat9-doc) |\
 Package (% =sdformat9-sdf)), \
-$Version (% 9.5.0-1~focal)) \
+$Version (% 9.5.0-1~*)) \
 "

--- a/config/ignition_edifice_debian_buster.yaml
+++ b/config/ignition_edifice_debian_buster.yaml
@@ -36,7 +36,7 @@ $Version (% 4.0.0-1~*)) |\
 Package (% =libignition-msgs7) |\
 Package (% =libignition-msgs7-dev) |\
 Package (% =libignition-msgs7-dbg)), \
-$Version (% 7.0.0-1~*)) |\
+$Version (% 7.1.0-1~*)) |\
 ((Package (% =ignition-physics4) |\
 Package (% libignition-physics4) |\
 Package (% libignition-physics4-core-dev) |\
@@ -49,7 +49,7 @@ Package (% libignition-physics4-tpe) |\
 Package (% libignition-physics4-tpe-dev) |\
 Package (% libignition-physics4-tpelib) |\
 Package (% libignition-physics4-tpelib-dev)), \
-$Version (% 4.0.0-1~*)) |\
+$Version (% 4.1.0-1~*)) |\
 ((Package (% =ignition-rendering5) |\
 Package (% =libignition-rendering5) |\
 Package (% =libignition-rendering5-core-dev) |\
@@ -89,6 +89,7 @@ Package (% =libignition-sensors5-thermal-camera) |\
 Package (% =libignition-sensors5-thermal-camera-dev)), \
 $Version (% 5.0.0-1~*)) |\
 ((Package (% =ignition-transport10) |\
+Package (% =libignition-transport10) |\
 Package (% libignition-transport10-core-dev) |\
 Package (% libignition-transport10-dbg) |\
 Package (% libignition-transport10-dev) |\
@@ -109,5 +110,5 @@ Package (% =libsdformat11-dbg) |\
 Package (% =libsdformat11-dev) |\
 Package (% =sdformat11-doc) |\
 Package (% =sdformat11-sdf)), \
-$Version (% 11.0.0-1~*)) \
+$Version (% 11.1.0-1~*)) \
 "

--- a/config/ignition_edifice_debian_buster.yaml
+++ b/config/ignition_edifice_debian_buster.yaml
@@ -1,10 +1,10 @@
-name: ignition_edifice_debian_buster.yaml
+name: ignition_edifice_debian_buster
 method: http://packages.osrfoundation.org/gazebo/debian-stable
 suites: [buster]
 component: main
 architectures: [amd64, source]
 filter_formula: "\
-(Package (% =ignition-common4), $Version (% 4.0.0-1~buster)) |\
+(Package (% =ignition-common4), $Version (% 4.0.0-1~*)) |\
 ((Package (% =libignition-common4) |\
 Package (% =libignition-common4-av) |\
 Package (% =libignition-common4-av-dev) |\
@@ -16,27 +16,27 @@ Package (% =libignition-common4-graphics) |\
 Package (% =libignition-common4-graphics-dev) |\
 Package (% =libignition-common4-profiler) |\
 Package (% =libignition-common4-profiler-dev)), \
-$Version (% 4.0.0-1~buster)) |\
-(Package (% =ignition-edifice), $Version (% 1.0.0-1~buster)) |\
-(Package (% =ignition-fuel-tools6), $Version (% 6.0.0-1~buster)) |\
+$Version (% 4.0.0-1~*)) |\
+(Package (% =ignition-edifice), $Version (% 1.0.0-1~*)) |\
+(Package (% =ignition-fuel-tools6), $Version (% 6.0.0-1~*)) |\
 ((Package (% =ignition-gazebo5) |\
 Package (% =libignition-gazebo5) |\
 Package (% =libignition-gazebo5-dev) |\
 Package (% =libignition-gazebo5-plugins)), \
-$Version (% 5.0.0-1~buster)) |\
+$Version (% 5.0.0-1~*)) |\
 ((Package (% =ignition-gui5) |\
 Package (% libignition-gui5) |\
 Package (% libignition-gui5-dev)), \
-$Version (% 5.0.0-1~buster)) |\
+$Version (% 5.0.0-1~*)) |\
 ((Package (% =ignition-launch4) |\
 Package (% =libignition-launch4) |\
 Package (% =libignition-launch4-dev)), \
-$Version (% 4.0.0-1~buster)) |\
+$Version (% 4.0.0-1~*)) |\
 ((Package (% =ignition-msgs7) |\
 Package (% =libignition-msgs7) |\
 Package (% =libignition-msgs7-dev) |\
 Package (% =libignition-msgs7-dbg)), \
-$Version (% 7.0.0-1~buster)) |\
+$Version (% 7.0.0-1~*)) |\
 ((Package (% =ignition-physics4) |\
 Package (% libignition-physics4) |\
 Package (% libignition-physics4-core-dev) |\
@@ -49,7 +49,7 @@ Package (% libignition-physics4-tpe) |\
 Package (% libignition-physics4-tpe-dev) |\
 Package (% libignition-physics4-tpelib) |\
 Package (% libignition-physics4-tpelib-dev)), \
-$Version (% 4.0.0-1~buster)) |\
+$Version (% 4.0.0-1~*)) |\
 ((Package (% =ignition-rendering5) |\
 Package (% =libignition-rendering5) |\
 Package (% =libignition-rendering5-core-dev) |\
@@ -58,7 +58,7 @@ Package (% =libignition-rendering5-ogre1) |\
 Package (% =libignition-rendering5-ogre1-dev) |\
 Package (% =libignition-rendering5-ogre2) |\
 Package (% =libignition-rendering5-ogre2-dev)), \
-$Version (% 5.0.0-1~buster)) |\
+$Version (% 5.0.0-1~*)) |\
 ((Package (% =ignition-sensors5) |\
 Package (% =libignition-sensors5) |\
 Package (% =libignition-sensors5-air-pressure) |\
@@ -87,14 +87,14 @@ Package (% =libignition-sensors5-rgbd-camera) |\
 Package (% =libignition-sensors5-rgbd-camera-dev) |\
 Package (% =libignition-sensors5-thermal-camera) |\
 Package (% =libignition-sensors5-thermal-camera-dev)), \
-$Version (% 5.0.0-1~buster)) |\
+$Version (% 5.0.0-1~*)) |\
 ((Package (% =ignition-transport10) |\
 Package (% libignition-transport10-core-dev) |\
 Package (% libignition-transport10-dbg) |\
 Package (% libignition-transport10-dev) |\
 Package (% libignition-transport10-log) |\
 Package (% libignition-transport10-log-dev)), \
-$Version (% 10.0.0-1~buster)) |\
+$Version (% 10.0.0-1~*)) |\
 ((Package (% =ignition-utils1) |\
 Package (% libignition-utils1) |\
 Package (% libignition-utils1-core-dev) |\
@@ -102,12 +102,12 @@ Package (% libignition-utils1-dbg) |\
 Package (% libignition-utils1-dev) |\
 Package (% libignition-utils1-cli) |\
 Package (% libignition-utils1-cli-dev)), \
-$Version (% 1.0.0-1~buster)) |\
+$Version (% 1.0.0-1~*)) |\
 ((Package (% =sdformat11) |\
 Package (% =libsdformat11) |\
 Package (% =libsdformat11-dbg) |\
 Package (% =libsdformat11-dev) |\
 Package (% =sdformat11-doc) |\
 Package (% =sdformat11-sdf)), \
-$Version (% 11.0.0-1~buster)) \
+$Version (% 11.0.0-1~*)) \
 "

--- a/config/ignition_edifice_ubuntu_focal.yaml
+++ b/config/ignition_edifice_ubuntu_focal.yaml
@@ -4,8 +4,8 @@ suites: [focal]
 component: main
 architectures: [amd64, i386, armhf, arm64, source]
 filter_formula: "\
-(Package (% =ignition-common4), $Version (% 4.0.0-1~*)) |\
-((Package (% =libignition-common4) |\
+((Package (% =ignition-common4) |\
+Package (% =libignition-common4) |\
 Package (% =libignition-common4-av) |\
 Package (% =libignition-common4-av-dev) |\
 Package (% =libignition-common4-core-dev) |\
@@ -18,7 +18,10 @@ Package (% =libignition-common4-profiler) |\
 Package (% =libignition-common4-profiler-dev)), \
 $Version (% 4.0.0-1~*)) |\
 (Package (% =ignition-edifice), $Version (% 1.0.0-1~*)) |\
-(Package (% =ignition-fuel-tools6), $Version (% 6.0.0-1~*)) |\
+((Package (% =ignition-fuel-tools6) |\
+Package (% =libignition-fuel-tools6) |\
+Package (% =libignition-fuel-tools6-dev)), \
+$Version (% 6.0.0-1~*)) |\
 ((Package (% =ignition-gazebo5) |\
 Package (% =libignition-gazebo5) |\
 Package (% =libignition-gazebo5-dev) |\
@@ -36,7 +39,7 @@ $Version (% 4.0.0-1~*)) |\
 Package (% =libignition-msgs7) |\
 Package (% =libignition-msgs7-dev) |\
 Package (% =libignition-msgs7-dbg)), \
-$Version (% 7.0.0-1~*)) |\
+$Version (% 7.1.0-1~*)) |\
 ((Package (% =ignition-physics4) |\
 Package (% libignition-physics4) |\
 Package (% libignition-physics4-core-dev) |\
@@ -49,7 +52,7 @@ Package (% libignition-physics4-tpe) |\
 Package (% libignition-physics4-tpe-dev) |\
 Package (% libignition-physics4-tpelib) |\
 Package (% libignition-physics4-tpelib-dev)), \
-$Version (% 4.0.0-1~*)) |\
+$Version (% 4.1.0-1~*)) |\
 ((Package (% =ignition-rendering5) |\
 Package (% =libignition-rendering5) |\
 Package (% =libignition-rendering5-core-dev) |\
@@ -89,6 +92,7 @@ Package (% =libignition-sensors5-thermal-camera) |\
 Package (% =libignition-sensors5-thermal-camera-dev)), \
 $Version (% 5.0.0-1~*)) |\
 ((Package (% =ignition-transport10) |\
+Package (% =libignition-transport10) |\
 Package (% libignition-transport10-core-dev) |\
 Package (% libignition-transport10-dbg) |\
 Package (% libignition-transport10-dev) |\
@@ -109,5 +113,5 @@ Package (% =libsdformat11-dbg) |\
 Package (% =libsdformat11-dev) |\
 Package (% =sdformat11-doc) |\
 Package (% =sdformat11-sdf)), \
-$Version (% 11.0.0-1~*)) \
+$Version (% 11.1.0-1~*)) \
 "

--- a/config/ignition_edifice_ubuntu_focal.yaml
+++ b/config/ignition_edifice_ubuntu_focal.yaml
@@ -4,7 +4,7 @@ suites: [focal]
 component: main
 architectures: [amd64, i386, armhf, arm64, source]
 filter_formula: "\
-(Package (% =ignition-common4), $Version (% 4.0.0-1~focal)) |\
+(Package (% =ignition-common4), $Version (% 4.0.0-1~*)) |\
 ((Package (% =libignition-common4) |\
 Package (% =libignition-common4-av) |\
 Package (% =libignition-common4-av-dev) |\
@@ -16,27 +16,27 @@ Package (% =libignition-common4-graphics) |\
 Package (% =libignition-common4-graphics-dev) |\
 Package (% =libignition-common4-profiler) |\
 Package (% =libignition-common4-profiler-dev)), \
-$Version (% 4.0.0-1~focal)) |\
-(Package (% =ignition-edifice), $Version (% 1.0.0-1~focal)) |\
-(Package (% =ignition-fuel-tools6), $Version (% 6.0.0-1~focal)) |\
+$Version (% 4.0.0-1~*)) |\
+(Package (% =ignition-edifice), $Version (% 1.0.0-1~*)) |\
+(Package (% =ignition-fuel-tools6), $Version (% 6.0.0-1~*)) |\
 ((Package (% =ignition-gazebo5) |\
 Package (% =libignition-gazebo5) |\
 Package (% =libignition-gazebo5-dev) |\
 Package (% =libignition-gazebo5-plugins)), \
-$Version (% 5.0.0-1~focal)) |\
+$Version (% 5.0.0-1~*)) |\
 ((Package (% =ignition-gui5) |\
 Package (% libignition-gui5) |\
 Package (% libignition-gui5-dev)), \
-$Version (% 5.0.0-1~focal)) |\
+$Version (% 5.0.0-1~*)) |\
 ((Package (% =ignition-launch4) |\
 Package (% =libignition-launch4) |\
 Package (% =libignition-launch4-dev)), \
-$Version (% 4.0.0-1~focal)) |\
+$Version (% 4.0.0-1~*)) |\
 ((Package (% =ignition-msgs7) |\
 Package (% =libignition-msgs7) |\
 Package (% =libignition-msgs7-dev) |\
 Package (% =libignition-msgs7-dbg)), \
-$Version (% 7.0.0-1~focal)) |\
+$Version (% 7.0.0-1~*)) |\
 ((Package (% =ignition-physics4) |\
 Package (% libignition-physics4) |\
 Package (% libignition-physics4-core-dev) |\
@@ -49,7 +49,7 @@ Package (% libignition-physics4-tpe) |\
 Package (% libignition-physics4-tpe-dev) |\
 Package (% libignition-physics4-tpelib) |\
 Package (% libignition-physics4-tpelib-dev)), \
-$Version (% 4.0.0-1~focal)) |\
+$Version (% 4.0.0-1~*)) |\
 ((Package (% =ignition-rendering5) |\
 Package (% =libignition-rendering5) |\
 Package (% =libignition-rendering5-core-dev) |\
@@ -58,7 +58,7 @@ Package (% =libignition-rendering5-ogre1) |\
 Package (% =libignition-rendering5-ogre1-dev) |\
 Package (% =libignition-rendering5-ogre2) |\
 Package (% =libignition-rendering5-ogre2-dev)), \
-$Version (% 5.0.0-1~focal)) |\
+$Version (% 5.0.0-1~*)) |\
 ((Package (% =ignition-sensors5) |\
 Package (% =libignition-sensors5) |\
 Package (% =libignition-sensors5-air-pressure) |\
@@ -87,14 +87,14 @@ Package (% =libignition-sensors5-rgbd-camera) |\
 Package (% =libignition-sensors5-rgbd-camera-dev) |\
 Package (% =libignition-sensors5-thermal-camera) |\
 Package (% =libignition-sensors5-thermal-camera-dev)), \
-$Version (% 5.0.0-1~focal)) |\
+$Version (% 5.0.0-1~*)) |\
 ((Package (% =ignition-transport10) |\
 Package (% libignition-transport10-core-dev) |\
 Package (% libignition-transport10-dbg) |\
 Package (% libignition-transport10-dev) |\
 Package (% libignition-transport10-log) |\
 Package (% libignition-transport10-log-dev)), \
-$Version (% 10.0.0-1~focal)) |\
+$Version (% 10.0.0-1~*)) |\
 ((Package (% =ignition-utils1) |\
 Package (% libignition-utils1) |\
 Package (% libignition-utils1-core-dev) |\
@@ -102,12 +102,12 @@ Package (% libignition-utils1-dbg) |\
 Package (% libignition-utils1-dev) |\
 Package (% libignition-utils1-cli) |\
 Package (% libignition-utils1-cli-dev)), \
-$Version (% 1.0.0*)) |\
+$Version (% 1.0.0-1~*)) |\
 ((Package (% =sdformat11) |\
 Package (% =libsdformat11) |\
 Package (% =libsdformat11-dbg) |\
 Package (% =libsdformat11-dev) |\
 Package (% =sdformat11-doc) |\
 Package (% =sdformat11-sdf)), \
-$Version (% 11.0.0-1~focal)) \
+$Version (% 11.0.0-1~*)) \
 "


### PR DESCRIPTION
Focal imports failed after https://github.com/ros-infrastructure/reprepro-updater/pull/111

Compared to the Buster filters, Focal was missing a lot of sub-packages. I had assumed there was some globbing going on, but that doesn't seem to be the case.

This PR makes Focal and Buster as similar as they can be by using `*` for the distro name. This should make it easier to compare them:

```.diff
$ diff -u config/ignition_edifice_debian_buster.yaml config/ignition_edifice_ubuntu_focal.yaml 
--- config/ignition_edifice_debian_buster.yaml	2021-05-04 16:39:32.060849643 -0700
+++ config/ignition_edifice_ubuntu_focal.yaml	2021-05-04 16:39:11.708572984 -0700
@@ -1,8 +1,8 @@
-name: ignition_edifice_debian_buster
-method: http://packages.osrfoundation.org/gazebo/debian-stable
-suites: [buster]
+name: ignition_edifice_ubuntu_focal
+method: http://packages.osrfoundation.org/gazebo/ubuntu-stable
+suites: [focal]
 component: main
-architectures: [amd64, source]
+architectures: [amd64, i386, armhf, arm64, source]
 filter_formula: "\
 (Package (% =ignition-common4), $Version (% 4.0.0-1~*)) |\
 ((Package (% =libignition-common4) |\
```

```.diff
$ diff -u config/ignition_edifice_debian_buster.yaml config/ignition_edifice_ubuntu_focal.yaml 
--- config/ignition_edifice_debian_buster.yaml	2021-05-04 16:39:32.060849643 -0700
+++ config/ignition_edifice_ubuntu_focal.yaml	2021-05-04 16:39:11.708572984 -0700
@@ -1,8 +1,8 @@
-name: ignition_edifice_debian_buster
-method: http://packages.osrfoundation.org/gazebo/debian-stable
-suites: [buster]
+name: ignition_edifice_ubuntu_focal
+method: http://packages.osrfoundation.org/gazebo/ubuntu-stable
+suites: [focal]
 component: main
-architectures: [amd64, source]
+architectures: [amd64, i386, armhf, arm64, source]
 filter_formula: "\
 (Package (% =ignition-common4), $Version (% 4.0.0-1~*)) |\
 ((Package (% =libignition-common4) |\

```