### PR TITLE
Ignition: bump ign-cmake2 and gazebo11 and add ignition-fuel-tools to Buster.

### DIFF
--- a/config/ignition_citadel_gazebo11_debian_buster.yaml
+++ b/config/ignition_citadel_gazebo11_debian_buster.yaml
@@ -10,7 +10,7 @@ Package (% =gazebo11-dbg) |\
 Package (% =gazebo11-doc) |\
 Package (% =libgazebo11) |\
 Package (% =libgazebo11-dev)), \
-$Version (% 11.5.0-1~*)) |\
+$Version (% 11.5.1-1~*)) |\
 ((Package (% =ignition-cmake2) |\
 Package (% =libignition-cmake2-dev)) |\
 $Version (% 2.8.0-1~*)) |\

--- a/config/ignition_citadel_gazebo11_debian_buster.yaml
+++ b/config/ignition_citadel_gazebo11_debian_buster.yaml
@@ -13,7 +13,7 @@ Package (% =libgazebo11-dev)), \
 $Version (% 11.5.0-1~*)) |\
 ((Package (% =ignition-cmake2) |\
 Package (% =libignition-cmake2-dev)) |\
-$Version (% 2.7.0-1~*)) |\
+$Version (% 2.8.0-1~*)) |\
 (Package (% =ignition-citadel), $Version (% 1.0.0*))|\
 ((Package (% =ignition-common3) |\
 Package (% =libignition-common3) |\
@@ -28,7 +28,10 @@ Package (% =libignition-common3-graphics-dev) |\
 Package (% =libignition-common3-profiler) |\
 Package (% =libignition-common3-profiler-dev)), \
 $Version (% 3.12.0-1~*)) |\
-(Package (% =ignition-fuel-tools4), $Version (% 4.3.0-1~*)) |\
+((Package (% =ignition-fuel-tools4) |\
+Package (% =libignition-fuel-tools4) |\
+Package (% =libignition-fuel-tools4-dev)), \
+$Version (% 4.3.0-1~*)) |\
 ((Package (% =ignition-gazebo3) |\
 Package (% =libignition-gazebo3) |\
 Package (% =libignition-gazebo3-dev) |\

--- a/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
+++ b/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
@@ -13,7 +13,7 @@ Package (% =libgazebo11-dev)), \
 $Version (% 11.5.0-1~*)) |\
 ((Package (% =ignition-cmake2) |\
 Package (% =libignition-cmake2-dev)) |\
-$Version (% 2.7.0-1~*)) |\
+$Version (% 2.8.0-1~*)) |\
 (Package (% =ignition-citadel), $Version (% 1.0.0*))|\
 ((Package (% =ignition-common3) |\
 Package (% =libignition-common3) |\

--- a/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
+++ b/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
@@ -10,7 +10,7 @@ Package (% =gazebo11-dbg) |\
 Package (% =gazebo11-doc) |\
 Package (% =libgazebo11) |\
 Package (% =libgazebo11-dev)), \
-$Version (% 11.5.0-1~*)) |\
+$Version (% 11.5.1-1~*)) |\
 ((Package (% =ignition-cmake2) |\
 Package (% =libignition-cmake2-dev)) |\
 $Version (% 2.8.0-1~*)) |\


### PR DESCRIPTION
Follow-up to https://github.com/ros-infrastructure/reprepro-updater/pull/112

It's still failing to install `ignition-edifice` on Focal:

```
The following packages have unmet dependencies:
 ignition-edifice : Depends: libignition-cmake2-dev (>= 2.7.0) but 2.6.2-1~focal is to be installed
                    Depends: libignition-common4-dev but it is not going to be installed
                    Depends: libignition-fuel-tools6-dev but it is not going to be installed
                    Depends: libignition-gazebo5-dev but it is not going to be installed
                    Depends: libignition-gui5-dev but it is not going to be installed
                    Depends: libignition-launch4-dev but it is not going to be installed
                    Depends: libignition-math6-dev (>= 6.8.0) but 6.7.0-1~focal is to be installed
                    Depends: libignition-math6-eigen3-dev (>= 6.8.0) but it is not going to be installed
                    Depends: libignition-msgs7-dev but it is not going to be installed
                    Depends: libignition-physics4-dev but it is not going to be installed
                    Depends: libignition-plugin-dev (>= 1.2.0) but 1.1.0-1~focal is to be installed
                    Depends: libignition-rendering5-dev but it is not going to be installed
                    Depends: libignition-sensors5-dev but it is not going to be installed
                    Depends: libignition-tools-dev (>= 1.1.0) but 1.0.0-1~focal is to be installed
                    Depends: libignition-transport10-dev but it is not going to be installed
                    Depends: libignition-utils1-cli-dev but it is not going to be installed
                    Depends: libignition-utils1-dev but it is not going to be installed
                    Depends: libsdformat11-dev but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

I narrowed it down to 

```
libignition-utils1-dev : Depends: libignition-cmake2-dev (>= 2.7.0~pre1) but 2.6.2-1~focal is to be installed
```

I think 2.8.0 may have already been out when we the import job was run, which made 2.7 not be pulled and we were stuck with the old 2.6.2.

---

It would be nice to improve this process :upside_down_face:  I actually don't know if just pulling `ign-cmake2` will be enough, so this may not even be the end of this round.

The only suggestion I have is to always pull the latest versions of all libraries (abuse those globs!). I know there's a desire to keep track of what exact versions are being imported, but as noted along this series of PRs (#109 / #110 / #111 / #112), the versions listed on this file aren't accurately reflecting the state of the server.

If we always pull the latest versions:

* We're sure they all work together, because that's actively tested by the Ignition team
* We don't need to edit this file every time we need to make an upgrade (saves time)

