### PR TITLE
Missing gazebo11-plugin-base from #111

### DIFF
--- a/config/ignition_citadel_gazebo11_debian_buster.yaml
+++ b/config/ignition_citadel_gazebo11_debian_buster.yaml
@@ -8,6 +8,7 @@ filter_formula: "\
 Package (% =gazebo11-common) |\
 Package (% =gazebo11-dbg) |\
 Package (% =gazebo11-doc) |\
+Package (% =gazebo11-plugin-base) |\
 Package (% =libgazebo11) |\
 Package (% =libgazebo11-dev)), \
 $Version (% 11.5.1-1~*)) |\

--- a/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
+++ b/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
@@ -8,6 +8,7 @@ filter_formula: "\
 Package (% =gazebo11-common) |\
 Package (% =gazebo11-dbg) |\
 Package (% =gazebo11-doc) |\
+Package (% =gazebo11-plugin-base) |\
 Package (% =libgazebo11) |\
 Package (% =libgazebo11-dev)), \
 $Version (% 11.5.1-1~*)) |\

--- a/config/ignition_edifice_debian_buster.yaml
+++ b/config/ignition_edifice_debian_buster.yaml
@@ -4,8 +4,8 @@ suites: [buster]
 component: main
 architectures: [amd64, source]
 filter_formula: "\
-(Package (% =ignition-common4), $Version (% 4.0.0-1~*)) |\
-((Package (% =libignition-common4) |\
+((Package (% =ignition-common4) |\
+Package (% =libignition-common4) |\
 Package (% =libignition-common4-av) |\
 Package (% =libignition-common4-av-dev) |\
 Package (% =libignition-common4-core-dev) |\
@@ -18,7 +18,10 @@ Package (% =libignition-common4-profiler) |\
 Package (% =libignition-common4-profiler-dev)), \
 $Version (% 4.0.0-1~*)) |\
 (Package (% =ignition-edifice), $Version (% 1.0.0-1~*)) |\
-(Package (% =ignition-fuel-tools6), $Version (% 6.0.0-1~*)) |\
+((Package (% =ignition-fuel-tools6) |\
+Package (% =libignition-fuel-tools6) |\
+Package (% =libignition-fuel-tools6-dev)), \
+$Version (% 6.0.0-1~*)) |\
 ((Package (% =ignition-gazebo5) |\
 Package (% =libignition-gazebo5) |\
 Package (% =libignition-gazebo5-dev) |\


### PR DESCRIPTION
https://github.com/ros-infrastructure/reprepro-updater/pull/111 introduced a bug by removing `gazebo11-plugin-base`. This PR should fix it.

PR and sync will address https://github.com/osrf/gazebo/issues/2995