### PR TITLE
Fix typo in filter formula.

### DIFF
--- a/config/ignition_citadel_gazebo11_debian_buster.yaml
+++ b/config/ignition_citadel_gazebo11_debian_buster.yaml
@@ -12,7 +12,7 @@ Package (% =libgazebo11) |\
 Package (% =libgazebo11-dev)), \
 $Version (% 11.5.1-1~*)) |\
 ((Package (% =ignition-cmake2) |\
-Package (% =libignition-cmake2-dev)) |\
+Package (% =libignition-cmake2-dev)), \
 $Version (% 2.8.0-1~*)) |\
 (Package (% =ignition-citadel), $Version (% 1.0.0*))|\
 ((Package (% =ignition-common3) |\

--- a/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
+++ b/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
@@ -12,7 +12,7 @@ Package (% =libgazebo11) |\
 Package (% =libgazebo11-dev)), \
 $Version (% 11.5.1-1~*)) |\
 ((Package (% =ignition-cmake2) |\
-Package (% =libignition-cmake2-dev)) |\
+Package (% =libignition-cmake2-dev)), \
 $Version (% 2.8.0-1~*)) |\
 (Package (% =ignition-citadel), $Version (% 1.0.0*))|\
 ((Package (% =ignition-common3) |\


### PR DESCRIPTION
Because of this typo, any version of ignition-cmake2/libignition-cmake2
was being installed as well as any package with a version 2.7.0-1~*.