### PR TITLE
Update package versions to latest.

### DIFF
--- a/config/ignition_citadel_gazebo11_debian_buster.yaml
+++ b/config/ignition_citadel_gazebo11_debian_buster.yaml
@@ -28,7 +28,7 @@ Package (% =libignition-common3-graphics) |\
 Package (% =libignition-common3-graphics-dev) |\
 Package (% =libignition-common3-profiler) |\
 Package (% =libignition-common3-profiler-dev)), \
-$Version (% 3.12.0-1~*)) |\
+$Version (% 3.13.1-1~*)) |\
 ((Package (% =ignition-fuel-tools4) |\
 Package (% =libignition-fuel-tools4) |\
 Package (% =libignition-fuel-tools4-dev)), \
@@ -37,7 +37,7 @@ $Version (% 4.3.0-1~*)) |\
 Package (% =libignition-gazebo3) |\
 Package (% =libignition-gazebo3-dev) |\
 Package (% =libignition-gazebo3-plugins)), \
-$Version (% 3.8.0-1~*)) |\
+$Version (% 3.0.0-1~*)) |\
 ((Package (% =ignition-gui3) |\
 Package (% =libignition-gui3) |\
 Package (% =libignition-gui3-dev)), \
@@ -45,7 +45,7 @@ $Version (% 3.5.1-1~*)) |\
 ((Package (% =ignition-launch2) |\
 Package (% =libignition-launch2) |\
 Package (% =libignition-launch2-dev)), \
-$Version (% 2.2.1-1~*)) |\
+$Version (% 2.0.1-3~*)) |\
 ((Package (% =ignition-math6) |\
 Package (% =libignition-math6) |\
 Package (% =libignition-math6-dbg) |\
@@ -111,7 +111,10 @@ Package (% =libignition-sensors3-rgbd-camera) |\
 Package (% =libignition-sensors3-rgbd-camera-dev) |\
 Package (% =libignition-sensors3-thermal-camera) |\
 Package (% =libignition-sensors3-thermal-camera-dev)), \
-$Version (% 3.2.0-1~*)) |\
+$Version (% 3.0.0-2~*)) |\
+((Package (% =ignition-tools) |\
+Package (% =libignition-tools-dev)), \
+$Version (% 1.2.0-1~*)) |\
 ((Package (% =ignition-transport8) |\
 Package (% =libignition-transport8) |\
 Package (% =libignition-transport8-core-dev) |\
@@ -119,10 +122,7 @@ Package (% =libignition-transport8-dbg) |\
 Package (% =libignition-transport8-dev) |\
 Package (% =libignition-transport8-log) |\
 Package (% =libignition-transport8-log-dev)), \
-$Version (% 8.2.0-1~*)) |\
-((Package (% =ignition-tools) |\
-Package (% =libignition-tools-dev)), \
-$Version (% 1.2.0-1~*)) |\
+$Version (% 8.0.0-1~*)) |\
 ((Package (% =ogre-2.1) |\
 Package (% =libogre-2.1) |\
 Package (% =libogre-2.1-dev)),

--- a/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
+++ b/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
@@ -15,7 +15,7 @@ $Version (% 11.5.1-1~*)) |\
 ((Package (% =ignition-cmake2) |\
 Package (% =libignition-cmake2-dev)), \
 $Version (% 2.8.0-1~*)) |\
-(Package (% =ignition-citadel), $Version (% 1.0.0*))|\
+(Package (% =ignition-citadel), $Version (% 1.0.1*))|\
 ((Package (% =ignition-common3) |\
 Package (% =libignition-common3) |\
 Package (% =libignition-common3-av) |\
@@ -28,7 +28,7 @@ Package (% =libignition-common3-graphics) |\
 Package (% =libignition-common3-graphics-dev) |\
 Package (% =libignition-common3-profiler) |\
 Package (% =libignition-common3-profiler-dev)), \
-$Version (% 3.12.0-1~*)) |\
+$Version (% 3.13.1-1~*)) |\
 ((Package (% =ignition-fuel-tools4) |\
 Package (% =libignition-fuel-tools4) |\
 Package (% =libignition-fuel-tools4-dev)), \
@@ -112,6 +112,9 @@ Package (% =libignition-sensors3-rgbd-camera-dev) |\
 Package (% =libignition-sensors3-thermal-camera) |\
 Package (% =libignition-sensors3-thermal-camera-dev)), \
 $Version (% 3.2.0-1~*)) |\
+((Package (% =ignition-tools) |\
+Package (% =libignition-tools-dev)), \
+$Version (% 1.2.0-1~*)) |\
 ((Package (% =ignition-transport8) |\
 Package (% =libignition-transport8) |\
 Package (% =libignition-transport8-core-dev) |\
@@ -120,9 +123,6 @@ Package (% =libignition-transport8-dev) |\
 Package (% =libignition-transport8-log) |\
 Package (% =libignition-transport8-log-dev)), \
 $Version (% 8.2.0-1~*)) |\
-((Package (% =ignition-tools) |\
-Package (% =libignition-tools-dev)), \
-$Version (% 1.2.0-1~*)) |\
 ((Package (% =ogre-2.1) |\
 Package (% =libogre-2.1) |\
 Package (% =libogre-2.1-dev)),

--- a/config/ignition_edifice_debian_buster.yaml
+++ b/config/ignition_edifice_debian_buster.yaml
@@ -106,7 +106,7 @@ Package (% libignition-utils1-dbg) |\
 Package (% libignition-utils1-dev) |\
 Package (% libignition-utils1-cli) |\
 Package (% libignition-utils1-cli-dev)), \
-$Version (% 1.0.0-1~*)) |\
+$Version (% 1.0.0-2~*)) |\
 ((Package (% =sdformat11) |\
 Package (% =libsdformat11) |\
 Package (% =libsdformat11-dbg) |\


### PR DESCRIPTION
Still trying to settle on installable gazebo and ignition packages. I used some ad-hoc automation to grab the current versions from the Gazebo repositories and check that against what we had configured.

Shell scripts are in Fish so be sure to translate them to their POSIX equivalents

Grab the Sources manifests from the OSRF repostiories, I make the assumption that all binary packages we need to import are present in the configs and that all binary packages matching the source package versions are present in the OSRF repos.

```fish
 curl 'http://packages.osrfoundation.org/gazebo/debian-stable/dists/buster/main/source/Sources.gz' | zcat > debian-buster-sources
 curl 'http://packages.osrfoundation.org/gazebo/ubuntu-stable/dists/focal/main/source/Sources.gz' | zcat > ubuntu-focal-sources
```

I threw a quick Ruby script together just to get this done. `grab-packages.rb`

```ruby
#!/usr/bin/ruby

sources_file = ARGV.shift
sources = File.read(sources_file)
packages_select = ARGV.to_a

Package = Struct.new(:package, :version)
packages = []
package = nil
version = nil
sources.lines.each do |line|
  if line.match /\APackage: (.*)/
    package = $1
  end
  if line.match /\AVersion: (.*)/
    version = $1
  end
  if package and version
    packages << Package.new(package, version)
    package = nil
    version = nil
  end
end

puts packages.select{|p| packages_select.include? p.package}
```

And used it like so to extract package versions for each of the packages in 

```fish
ruby grab-packages ubuntu-focal-sources (cat config/ignition_edifice_ubuntu_focal.yaml | rg '(Package.*Version|\(\(Package)' | cut -d= -f2 | cut -d\) -f1)
ruby grab-packages debian-buster-sources (cat config/ignition_edifice_debian_buster.yaml | rg '(Package.*Version|\(\(Package)' | cut -d= -f2 | cut -d\) -f1)
ruby grab-packages ubuntu-focal-sources (cat config/ignition_citadel_gazebo11_ubuntu_focal.yaml | rg '(Package.*Version|\(\(Package)' | cut -d= -f2 | cut -d\) -f1)
ruby grab-packages debian-buster-sources (cat config/ignition_citadel_gazebo11_debian_buster.yaml | rg '(Package.*Version|\(\(Package)' | cut -d= -f2 | cut -d\) -f1)
```