### PR TITLE
Bump catkin_lint to 1.6.14

### DIFF
--- a/config/catkin_lint.upstream.yaml
+++ b/config/catkin_lint.upstream.yaml
@@ -3,4 +3,4 @@ method: http://ppa.launchpad.net/roehling/ros/ubuntu
 suites: [bionic, focal]
 component: main
 architectures: [i386, amd64, armhf, arm64, source]
-filter_formula: $Source (== catkin-lint), $Version (% 1.6.13-*)
+filter_formula: $Source (== catkin-lint), $Version (% 1.6.14-*)

--- a/config/catkin_lint.upstream.yaml
+++ b/config/catkin_lint.upstream.yaml
@@ -3,4 +3,4 @@ method: http://ppa.launchpad.net/roehling/ros/ubuntu
 suites: [bionic, focal]
 component: main
 architectures: [i386, amd64, armhf, arm64, source]
-filter_formula: (Package (= catkin-lint), $Source (= catkin-lint)), $Version (% 1.6.14-*)
+filter_formula: (Package (= catkin-lint) | $Source (= catkin-lint)), $Version (% 1.6.14-*)

--- a/config/catkin_lint.upstream.yaml
+++ b/config/catkin_lint.upstream.yaml
@@ -1,6 +1,6 @@
 name: catkin_lint
 method: http://ppa.launchpad.net/roehling/ros/ubuntu
-suites: [xenial, bionic, focal]
+suites: [bionic, focal]
 component: main
 architectures: [i386, amd64, armhf, arm64, source]
-filter_formula: Source (== catkin-lint), $Version (% 1.6.12-*)
+filter_formula: $Source (== catkin-lint), $Version (% 1.6.13-*)

--- a/config/catkin_lint.upstream.yaml
+++ b/config/catkin_lint.upstream.yaml
@@ -3,4 +3,4 @@ method: http://ppa.launchpad.net/roehling/ros/ubuntu
 suites: [bionic, focal]
 component: main
 architectures: [i386, amd64, armhf, arm64, source]
-filter_formula: $Source (= catkin-lint), $Version (% 1.6.14-*) #DUMMY
+filter_formula: $Source (= catkin-lint), $Version (% 1.6.14-*)

--- a/config/catkin_lint.upstream.yaml
+++ b/config/catkin_lint.upstream.yaml
@@ -3,4 +3,4 @@ method: http://ppa.launchpad.net/roehling/ros/ubuntu
 suites: [bionic, focal]
 component: main
 architectures: [i386, amd64, armhf, arm64, source]
-filter_formula: $Source (= catkin-lint), $Version (% 1.6.14-*)
+filter_formula: $Source (= catkin-lint), $Version (% 1.6.14-*) #DUMMY

--- a/config/catkin_lint.upstream.yaml
+++ b/config/catkin_lint.upstream.yaml
@@ -3,4 +3,4 @@ method: http://ppa.launchpad.net/roehling/ros/ubuntu
 suites: [bionic, focal]
 component: main
 architectures: [i386, amd64, armhf, arm64, source]
-filter_formula: $Source (== catkin-lint), $Version (% 1.6.14-*)
+filter_formula: $Source (= catkin-lint), $Version (% 1.6.14-*)

--- a/config/catkin_lint.upstream.yaml
+++ b/config/catkin_lint.upstream.yaml
@@ -3,4 +3,4 @@ method: http://ppa.launchpad.net/roehling/ros/ubuntu
 suites: [bionic, focal]
 component: main
 architectures: [i386, amd64, armhf, arm64, source]
-filter_formula: $Source (= catkin-lint), $Version (% 1.6.14-*)
+filter_formula: (Package (= catkin-lint), $Source (= catkin-lint)), $Version (% 1.6.14-*)


### PR DESCRIPTION
This will also remove Xenial (it's EOL and will no longer be updated in my PPA) and fix a bug in the FilterFormula that prevented propagation of all binary packages (`$Source` instead of `Source` is needed).