### PR TITLE
Spike out a change to allow overriding the source package requirement.

### DIFF
--- a/scripts/aptly/aptly_importer.py
+++ b/scripts/aptly/aptly_importer.py
@@ -175,6 +175,7 @@ class UpdaterConfiguration():
             self.method = self.config['method']
             self.name = self.config['name']
             self.suites = self.config['suites']
+            self.override_sources_required = self.config['override_sources_required']
         except KeyError as e:
             self.__error(f"{e} key was not found in file {input_file}")
 
@@ -313,13 +314,14 @@ class UpdaterManager():
         for dist in self.config.suites:
             # 1. Create aptly mirrors from yaml configuration file
             self.__create_aptly_mirror(dist)
-            # 2. Be sure mirror has all source packages
-            self.__log(f'Check all source packages exist')
-            if not self.aptly.exists_all_source_packages(Aptly.ArtifactType.MIRROR,
-                                                         self.__get_mirror_name(dist)):
-                self.__remove_all_generated_mirrors()
-                self.__error(f'{self.__get_mirror_name(dist)} does not have a source package. Removing generated mirrors')
-            self.__log_ok('All source packages exist in the mirror')
+            # 2. Be sure mirror has all source packages unless the requirement is overridden.
+            if self.config.override_sources_required:
+                self.__log(f'Check all source packages exist')
+                if not self.aptly.exists_all_source_packages(Aptly.ArtifactType.MIRROR,
+                                                             self.__get_mirror_name(dist)):
+                    self.__remove_all_generated_mirrors()
+                    self.__error(f'{self.__get_mirror_name(dist)} does not have a source package. Removing generated mirrors')
+                self.__log_ok('All source packages exist in the mirror')
             if self.only_mirror_creation:
                 return True
             # 2. Import from mirrors to local repositories


### PR DESCRIPTION
Considering the possibility of using this repository for gurumdds
updates as well but since that's a proprietary package redistributed by
agreement it does not have source packages available and thus we would
need to be able to override our own check.

This is a minimal change which adds a new implicitly boolean field but
I'd like to get feedback on further refactoring to allow overrides to be
package specific (although I have no immediate use case for it).

Examples:

Override all source requirements:

```
override_sources_required: true
```

Override requirements for specific packages

```
override_sources_required:
  - gurumdds-2.6
  - gurumdds-2.7
```