### PR TITLE
bump vcstool to 0.3.0

### DIFF
--- a/config/vcstool.debian.upstream.yaml
+++ b/config/vcstool.debian.upstream.yaml
@@ -3,4 +3,4 @@ method: https://packagecloud.io/dirk-thomas/vcstool/debian
 suites: [stretch, buster]
 component: main
 architectures: [i386, amd64, armhf, arm64, source]
-filter_formula: Package (% python3-vcstool, $Version (% 0.3.0*)
+filter_formula: Package (% python3-vcstool), $Version (% 0.3.0*)

--- a/config/vcstool.debian.upstream.yaml
+++ b/config/vcstool.debian.upstream.yaml
@@ -1,6 +1,6 @@
 name: vcstool
 method: https://packagecloud.io/dirk-thomas/vcstool/debian
-suites: [jessie, stretch, buster]
+suites: [stretch, buster]
 component: main
 architectures: [i386, amd64, armhf, arm64, source]
-filter_formula: Package (% python3-vcstool, $Version (% 0.2.14*)
+filter_formula: Package (% python3-vcstool, $Version (% 0.3.0*)

--- a/config/vcstool.ubuntu.upstream.yaml
+++ b/config/vcstool.ubuntu.upstream.yaml
@@ -3,4 +3,4 @@ method: https://packagecloud.io/dirk-thomas/vcstool/ubuntu
 suites: [xenial, bionic, focal]
 component: main
 architectures: [i386, amd64, armhf, arm64, source]
-filter_formula: Package (% python3-vcstool, $Version (% 0.2.14*)
+filter_formula: Package (% python3-vcstool, $Version (% 0.3.0*)

--- a/config/vcstool.ubuntu.upstream.yaml
+++ b/config/vcstool.ubuntu.upstream.yaml
@@ -3,4 +3,4 @@ method: https://packagecloud.io/dirk-thomas/vcstool/ubuntu
 suites: [xenial, bionic, focal]
 component: main
 architectures: [i386, amd64, armhf, arm64, source]
-filter_formula: Package (% python3-vcstool, $Version (% 0.3.0*)
+filter_formula: Package (% python3-vcstool), $Version (% 0.3.0*)


### PR DESCRIPTION
`vcstool` version dropped support for Python 2.7 and 3.4 hence the removal of `jessie`.