### PR TITLE
Add bullseye key to test scripts.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,10 @@ jobs:
       - name: Setup enviroment
         run: |
             gpg --no-default-keyring --keyring /usr/share/keyrings/ubuntu-archive-keyring.gpg --export | gpg --no-default-keyring --keyring trustedkeys.gpg --import
-            gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys 16E90B3FDF65EDE3AA7F323C04EE7237B7D453EC
-            gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys 0146DC6D4A0B2914BDED34DB648ACFD622F3D138
-            gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys 67170598AF249743
+            gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys 16E90B3FDF65EDE3AA7F323C04EE7237B7D453EC # Debian Stretch
+            gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys 0146DC6D4A0B2914BDED34DB648ACFD622F3D138 # Debian Buster
+            gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys 0E98404D386FA1D9 # Debian Bullseye 
+            gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys 67170598AF249743 # OSRF Repository
 
       - name: Generate key
         run: |


### PR DESCRIPTION
This is pretty brittle in general, I wonder if we can trust a top level
key or import all Debian keys as we do with the Ubuntu keys (which is
easy because we're running the CI on Ubuntu.)