### PR TITLE
Ignition Citadel: Buster i386, armhf and arm64

### DIFF
--- a/config/ignition_citadel_gazebo11_debian_buster.yaml
+++ b/config/ignition_citadel_gazebo11_debian_buster.yaml
@@ -2,7 +2,7 @@ name: ignition_citadel_gazebo11_debian_buster
 method: http://packages.osrfoundation.org/gazebo/debian-stable
 suites: [buster]
 component: main
-architectures: [amd64, source]
+architectures: [amd64, i386, armhf, arm64, source]
 filter_formula: "\
 ((Package (% =gazebo11) |\
 Package (% =gazebo11-common) |\


### PR DESCRIPTION
Most Ignition packages are available for those architectures, so it would be nice to import them here.

This is meant to fix https://github.com/ignitionrobotics/ros_ign/issues/173

As a reference, here are the current packages available on packages.osrfoundation.org, generated with [this script](https://github.com/ignition-tooling/release-tools/blob/master/terminal-dashboard/table.bash):

![image](https://user-images.githubusercontent.com/5751272/142090853-c3aa96f0-df99-4be6-b28a-ff9fd6a44c12.png)

<details><summary>As text</summary>
<p>

```
ignition-cmake2
bionic   amd64    2.9.0-1    i386     2.9.0-1    arm64    2.9.0-1    armhf    2.9.0-1   
focal    amd64    2.9.0-1    i386     disabled   arm64    2.9.0-1    armhf    2.9.0-1   
buster   amd64    2.9.0-1    i386     2.9.0-1    arm64    2.9.0-1    armhf    2.9.0-1   
ignition-math6
bionic   amd64    6.9.2-1    i386     6.9.2-1    arm64    6.9.2-1    armhf    6.9.2-1   
focal    amd64    6.9.2-1    i386     disabled   arm64    6.9.2-1    armhf    6.9.2-1   
buster   amd64    6.9.2-1    i386     6.9.2-1    arm64    6.9.2-1    armhf    6.9.2-1   
ignition-tools
bionic   amd64    1.4.1-1    i386     1.4.1-1    arm64    1.4.1-1    armhf    1.4.1-1   
focal    amd64    1.4.1-1    i386     disabled   arm64    1.4.1-1    armhf    1.4.1-1   
buster   amd64    1.4.1-1    i386     1.4.1-1    arm64    1.4.1-1    armhf    1.4.1-1   
ignition-common3
bionic   amd64    3.14.0-1   i386     3.14.0-1   arm64    3.14.0-1   armhf    3.14.0-1  
focal    amd64    3.14.0-1   i386     disabled   arm64    3.14.0-1   armhf    3.14.0-1  
buster   amd64    3.14.0-1   i386     3.14.0-1   arm64    3.14.0-1   armhf    3.14.0-1  
ignition-msgs5
bionic   amd64    5.8.1-1    i386     5.8.1-1    arm64    5.8.1-1    armhf    5.8.1-1   
focal    amd64    5.8.1-1    i386     disabled   arm64    5.8.1-1    armhf    5.8.1-1   
buster   amd64    5.8.1-1    i386     5.8.1-1    arm64    5.8.1-1    armhf    5.8.1-1   
ignition-transport8
bionic   amd64    8.2.1-1    i386     8.2.1-1    arm64    8.2.1-1    armhf    8.2.1-1   
focal    amd64    8.2.1-1    i386     disabled   arm64    8.2.1-1    armhf    8.2.1-1   
buster   amd64    8.2.1-1    i386     8.2.1-1    arm64    8.2.1-1    armhf    8.2.1-1   
ignition-fuel-tools4
bionic   amd64    4.4.0-1    i386     4.4.0-1    arm64    4.4.0-1    armhf    4.4.0-1   
focal    amd64    4.4.0-1    i386     disabled   arm64    4.4.0-1    armhf    4.4.0-1   
buster   amd64    4.4.0-1    i386     4.4.0-1    arm64    4.4.0-1    armhf    4.4.0-1   
ignition-plugin
bionic   amd64    1.2.1-1    i386     1.2.1-1    arm64    1.2.1-1    armhf    1.2.1-1   
focal    amd64    1.2.1-1    i386     disabled   arm64    1.2.1-1    armhf    1.2.1-1   
buster   amd64    1.2.1-1    i386     1.2.1-1    arm64    1.2.1-1    armhf    1.2.1-1   
ignition-rendering3
bionic   amd64    3.6.0-1    i386     3.6.0-1    arm64    3.6.0-1    armhf    not-found 
focal    amd64    3.6.0-1    i386     disabled   arm64    3.6.0-1    armhf    3.6.0-1   
buster   amd64    3.6.0-1    i386     not-found  arm64    3.6.0-1    armhf    3.6.0-1   
sdformat9
bionic   amd64    9.7.0-1    i386     9.7.0-1    arm64    9.7.0-1    armhf    9.7.0-1   
focal    amd64    9.7.0-1    i386     disabled   arm64    9.7.0-1    armhf    9.7.0-1   
buster   amd64    9.7.0-1    i386     9.7.0-1    arm64    9.7.0-1    armhf    9.7.0-1   
ignition-physics2
bionic   amd64    2.5.0-1    i386     2.5.0-1    arm64    2.5.0-1    armhf    2.5.0-1   
focal    amd64    2.5.0-1    i386     disabled   arm64    2.5.0-1    armhf    2.5.0-1   
buster   amd64    2.5.0-1    i386     not-found  arm64    not-found  armhf    not-found 
ignition-sensors3
bionic   amd64    3.3.0-1    i386     3.3.0-1    arm64    3.3.0-1    armhf    not-found 
focal    amd64    3.3.0-1    i386     disabled   arm64    3.3.0-1    armhf    3.3.0-1   
buster   amd64    3.3.0-1    i386     not-found  arm64    3.3.0-1    armhf    3.3.0-1   
ignition-gui3
bionic   amd64    3.8.0-1    i386     3.8.0-1    arm64    3.8.0-1    armhf    not-found 
focal    amd64    3.8.0-1    i386     disabled   arm64    3.8.0-1    armhf    3.8.0-1   
buster   amd64    3.8.0-1    i386     not-found  arm64    3.8.0-1    armhf    3.8.0-1   
ignition-gazebo3
bionic   amd64    3.12.0-1   i386     3.12.0-1   arm64    3.12.0-1   armhf    not-found 
focal    amd64    3.12.0-1   i386     disabled   arm64    3.11.0-1   armhf    3.12.0-1  
buster   amd64    3.12.0-1   i386     not-found  arm64    not-found  armhf    not-found 
ignition-launch2
bionic   amd64    2.2.2-1    i386     2.1.0-1    arm64    2.2.2-1    armhf    not-found 
focal    amd64    2.2.2-1    i386     disabled   arm64    2.2.2-1    armhf    2.2.2-1   
buster   amd64    2.2.2-1    i386     not-found  arm64    not-found  armhf    not-found 
ignition-citadel
bionic   amd64    1.0.2-1    i386     1.0.0-1    arm64    1.0.2-1    armhf    not-found 
focal    amd64    1.0.2-1    i386     disabled   arm64    1.0.1-1    armhf    1.0.2-1   
buster   amd64    1.0.2-1    i386     not-found  arm64    not-found  armhf    not-found 

```


</p>
</details>

