### PR TITLE
Missing libignition-physics4-heightmap-dev for edifice

### DIFF
--- a/config/ignition_edifice_debian_buster.yaml
+++ b/config/ignition_edifice_debian_buster.yaml
@@ -42,6 +42,8 @@ Package (% =libignition-msgs7-dbg)), \
 $Version (% 7.2.0-*)) |\
 ((Package (% =ignition-physics4) |\
 Package (% libignition-physics4) |\
+Package (% libignition-physics4-bullet-dev) |\
+Package (% libignition-physics4-bullet) |\
 Package (% libignition-physics4-core-dev) |\
 Package (% libignition-physics4-dartsim) |\
 Package (% libignition-physics4-dartsim-dev) |\

--- a/config/ignition_edifice_debian_buster.yaml
+++ b/config/ignition_edifice_debian_buster.yaml
@@ -46,6 +46,7 @@ Package (% libignition-physics4-core-dev) |\
 Package (% libignition-physics4-dartsim) |\
 Package (% libignition-physics4-dartsim-dev) |\
 Package (% libignition-physics4-dev) |\
+Package (% libignition-physics4-heightmap-dev) |\
 Package (% libignition-physics4-mesh-dev) |\
 Package (% libignition-physics4-sdf-dev) |\
 Package (% libignition-physics4-tpe) |\

--- a/config/ignition_edifice_ubuntu_focal.yaml
+++ b/config/ignition_edifice_ubuntu_focal.yaml
@@ -42,6 +42,8 @@ Package (% =libignition-msgs7-dbg)), \
 $Version (% 7.2.0-*)) |\
 ((Package (% =ignition-physics4) |\
 Package (% libignition-physics4) |\
+Package (% libignition-physics4-bullet-dev) |\
+Package (% libignition-physics4-bullet) |\
 Package (% libignition-physics4-core-dev) |\
 Package (% libignition-physics4-dartsim) |\
 Package (% libignition-physics4-dartsim-dev) |\

--- a/config/ignition_edifice_ubuntu_focal.yaml
+++ b/config/ignition_edifice_ubuntu_focal.yaml
@@ -46,6 +46,7 @@ Package (% libignition-physics4-core-dev) |\
 Package (% libignition-physics4-dartsim) |\
 Package (% libignition-physics4-dartsim-dev) |\
 Package (% libignition-physics4-dev) |\
+Package (% libignition-physics4-heightmap-dev) |\
 Package (% libignition-physics4-mesh-dev) |\
 Package (% libignition-physics4-sdf-dev) |\
 Package (% libignition-physics4-tpe) |\


### PR DESCRIPTION
Caused by https://github.com/ros-infrastructure/reprepro-updater/issues/133 to complete #131. 
Reviewing the dependencies manually I did not find other missing pieces.