### PR TITLE
Add Ogre 2.2 (For Ignition Fortress)

### DIFF
--- a/config/ignition_fortress_debian_buster.yaml
+++ b/config/ignition_fortress_debian_buster.yaml
@@ -93,6 +93,10 @@ Package (% libignition-transport11-dev) |\
 Package (% libignition-transport11-log) |\
 Package (% libignition-transport11-log-dev)), \
 $Version (% 11.0.0-*)) |\
+((Package (% =ogre-2.2) |\
+Package (% =libogre-2.2) |\
+Package (% =libogre-2.2-dev)),
+$Version (% 2.2.5+*)) |\
 ((Package (% =sdformat12) |\
 Package (% =libsdformat12) |\
 Package (% =libsdformat12-dbg) |\

--- a/config/ignition_fortress_ubuntu_focal.yaml
+++ b/config/ignition_fortress_ubuntu_focal.yaml
@@ -93,6 +93,10 @@ Package (% libignition-transport11-dev) |\
 Package (% libignition-transport11-log) |\
 Package (% libignition-transport11-log-dev)), \
 $Version (% 11.0.0-*)) |\
+((Package (% =ogre-2.2) |\
+Package (% =libogre-2.2) |\
+Package (% =libogre-2.2-dev)),
+$Version (% 2.2.5+*)) |\
 ((Package (% =sdformat12) |\
 Package (% =libsdformat12) |\
 Package (% =libsdformat12-dbg) |\


### PR DESCRIPTION
* Follow up to #128 , it's currently not possible to install `ignition-fortress` just with packages.ros.org

I copied what we have for Ogre 2.1 on Citadel:

https://github.com/ros-infrastructure/reprepro-updater/blob/78a5edd2dad41479dcc3ead254eb6db2dc7bbd9f/config/ignition_citadel_gazebo11_ubuntu_focal.yaml#L126-L129

These are the versions we have on packages.osrfoundation.org

```
libogre-2.2-dev/unknown,now 2.2.5+20210824~ec3f70c-4osrf~focal amd64 [installed]
libogre-2.2/unknown,now 2.2.5+20210824~ec3f70c-4osrf~focal amd64 [installed,automatic]
ogre-2.2-doc/unknown,unknown 2.2.5+20210824~ec3f70c-4osrf~focal all
ogre-2.2-tools/unknown 2.2.5+20210824~ec3f70c-4osrf~focal amd64
```