### PR TITLE
Add new import configuration for Ignition Fortress on Ubuntu Jammy.

### DIFF
--- a/config/ignition_fortress_ubuntu_jammy.yaml
+++ b/config/ignition_fortress_ubuntu_jammy.yaml
@@ -1,0 +1,17 @@
+name: ignition_fortress_ubuntu_jammy
+method: http://packages.osrfoundation.org/gazebo/ubuntu-stable
+suites: [jammy]
+component: main
+architectures: [amd64, i386, armhf, arm64, source]
+filter_formula: "\
+((Package (= ignition-cmake2) |\
+ (Package (= libignition-cmake2-dev)
+), $Version (% 2.10.0-*) |\
+((Package (= ignition-math6) |\
+ (Package (= libignition-math6) |\
+ (Package (= libignition-math6-dbg) |\
+ (Package (= libignition-math6-dev) |\
+ (Package (= libignition-math6-eigen3-dev) |\
+ (Package (= python3-ignition-math6)
+), $Version (% 6.10.0-*) \
+"


### PR DESCRIPTION
Currently only ignition-cmake and ignition-math are available.

I'm prototyping a script in [another branch](https://github.com/ros-infrastructure/reprepro-updater/tree/nuclearsandwich/generating-ignition-configs) to generate these config files by inspecting the upstream repository hence the slightly different formatting which hopefully improves readability.