### PR TITLE
Add a script for generating import configurations from the live Ignition repositories.

### DIFF
--- a/scripts/generate_ignition_import_config.py
+++ b/scripts/generate_ignition_import_config.py
@@ -92,7 +92,7 @@ for idx in range(0, len(printable_groups)):
     if not pgroup.version_spec:
         continue
     print('(', end='')
-    print(' |\\\n '.join(f'(Package (= {name})' for name in pgroup.packages))
+    print(' |\\\n '.join(f'Package (= {name})' for name in pgroup.packages))
     print(f'), $Version (% {pgroup.version_spec})', end='')
     if idx != len(printable_groups) - 1:
         print(' |\\')

--- a/scripts/generate_ignition_import_config.py
+++ b/scripts/generate_ignition_import_config.py
@@ -10,19 +10,27 @@ from typing import List, Union
 @dataclass
 class Package:
     name: str
+    source_package: str
     version: str
 
 class PackagesFile:
     def __init__(self, file_contents):
         self.packages = dict()
         current_package = None
+        current_source = None
+        current_version = None
         for line in file_contents.splitlines():
+            if line.startswith('Source: '):
+                current_source = line.split(': ')[1]
             if line.startswith('Version: '):
-                assert current_package
-                _, version = line.split(': ')
-                self.packages[current_package] = Package(current_package, version)
+                current_version = line.split(': ')[1]
             if line.startswith('Package: '):
-                _, current_package = line.split(': ')
+                if current_package:
+                    assert current_version and current_source
+                    self.packages[current_package] = Package(current_package, current_source, current_version)
+                    current_source = None
+                    current_version = None
+                current_package = line.split(': ')[1]
 
 
 @dataclass
@@ -34,40 +42,21 @@ class PackageGroup:
 IGNITION_SUITE='fortress'
 
 PACKAGES = [
-        PackageGroup((f'ignition-{IGNITION_SUITE}',), version_spec=None),
-        PackageGroup(('ignition-cmake2', 'libignition-cmake2', 'libignition-cmake2-dev'), version_spec=None),
-        PackageGroup(('ignition-fuel-tools7', 'libignition-fuel-tools7', 'libignition-fuel-tools7-dev'), version_spec=None),
-        PackageGroup(('ignition-gazebo6', 'libignition-gazebo6', 'libignition-gazebo6-dev', 'libignition-gazebo6-plugins'), version_spec=None),
-        PackageGroup(('ignition-gui6', 'libignition-gui6', 'libignition-gui6-dev'), version_spec=None),
-        PackageGroup(('ignition-launch5', 'libignition-launch5', 'libignition-launch5-dev'), version_spec=None),
-        PackageGroup(('ignition-math6', 'libignition-math6', 'libignition-math6-dbg', 'libignition-math6-dev', 'libignition-math6-eigen-dev', 'python3-ignition-math6', 'ruby-ignition-math6'), version_spec=None),
-        PackageGroup(('ignition-msgs8', 'libignition-msgs8', 'libignition-msgs8-dev', 'libignition-msgs8-dbg'), version_spec=None),
-        PackageGroup(('ignition-physics5',  'libignition-physics5', 'libignition-physics5-bullet','libignition-physics5-bullet-dev',
-            'libignition-physics5-core-dev', 'libignition-physics5-dartsim', 'libignition-physics5-dartsim-dev',
-            'libignition-physics5-dev', 'libignition-heightmap-dev', 'libignition-physics5-mesh-dev', 'libignition-physics5-sdf-dev',
-            'libignition-physics5-tpe', 'libignition-physics5-tpe-dev', 'libignition-physics5-tpelib', 'libignition-physics5-tpelib-dev'
-            ), version_spec=None),
-        PackageGroup(('ignition-rendering6', 'libignition-rendering6', 'libignition-rendering6-core-dev',
-            'libignition-rendering6-dev', 'libignition-rendering6-ogre1', 'libignition-rendering6-ogre1-dev',
-            'libignition-rendering6-ogre2', 'libignition-rendering6-ogre2-dev'), version_spec=None),
-        PackageGroup(('ignition-sensors6', 'libignition-sensors6', 'libignition-sensors6-air-pressure', 'libignition-sensors6-air-pressure-dev',
-            'libignition-sensors6-altimeter', 'libignition-sensors6-altimeter-dev', 'libignition-sensors6-camera', 'libignition-sensors6-camera-dev',
-            'libignition-sensors6-depth-camera', 'libignition-sensors6-depth-camera-dev' 'libignition-sensors6-dev',
-            'libignition-sensors6-force-torque', 'libignition-sensors6-force-torque-dev', 'libignition-gpu-lidar', 'libignition-gpu-lidar-dev',
-            'libignition-imu', 'libignition-imu-dev', 'libignition-sensors6-lidar', 'libignition-sensors6-lidar-dev',
-            'libignition-sensors6-logical-camera', 'libignition-sensors6-logical-camera-dev',
-            'libignition-sensors6-magnetometer', 'libignition-sensors6-magnetometer-dev', 
-            'libignition-sensors6-rendering', 'libignition-sensors6-rendering-dev', 
-            'libignition-sensors6-rgbd-camera', 'libignition-sensors6-rgbd-camera-dev', 
-            'libignition-sensors6-segmentation-camera', 'libignition-sensors6-segmentation-camera-dev', 
-            'libignition-sensors6-thermal-camera', 'libignition-sensors6-thermal-camera-dev'
-            ), version_spec=None),
-        PackageGroup(('ignition-transport11', 'libignition-transport11', 'libignition-transport11-core-dev',
-            'libignition-transport11-dbg', 'libignition-transport11-dev',
-            'libignition-transport11-log', 'libignition-transport11-log-dev'), version_spec=None),
-        PackageGroup(('ogre-2.2', 'libogre-2.2', 'libogre-2.2-dev'), version_spec=None),
-        PackageGroup(('sdformat12', 'libsdformat12', 'libsdformat12-dbg', 'libsdformat12-dev', 'sdformat12-doc', 'sdformat12-sdf'), version_spec=None),
-        ]
+        PackageGroup(f'ignition-{IGNITION_SUITE}', packages=None, version_spec=None),
+        PackageGroup('ignition-cmake2', packages=None, version_spec=None),
+        PackageGroup('ignition-fuel-tools7', packages=None, version_spec=None),
+        PackageGroup('ignition-gazebo6', packages=None, version_spec=None),
+        PackageGroup('ignition-gui6', packages=None, version_spec=None),
+        PackageGroup('ignition-launch5', packages=None, version_spec=None),
+        PackageGroup('ignition-math6', packages=None, version_spec=None),
+        PackageGroup('ignition-msgs8', packages=None, version_spec=None),
+        PackageGroup('ignition-physics5', packages=None, version_spec=None),
+        PackageGroup('ignition-rendering6', packages=None, version_spec=None),
+        PackageGroup('ignition-sensors6', packages=None, version_spec=None),
+        PackageGroup('ignition-transport11', packages=None, version_spec=None),
+        PackageGroup('ogre-2.2', packages=None, version_spec=None),
+        PackageGroup('sdformat12', packages=None, version_spec=None),
+    ]
 
 OS = 'ubuntu'
 TARGET_REPO = f'http://packages.osrfoundation.org/gazebo/{OS}-stable'
@@ -79,20 +68,17 @@ packages_file = PackagesFile(resp.read().decode())
 
 for group in PACKAGES:
     expected_group_version = None
+    group.packages = [pkg.name for pkg in packages_file.packages.values() if pkg.source_package == group.source_package]
     for p in group.packages:
-        if p not in packages_file.packages:
-            print(f'Binary package {p} not found in {TARGET_REPO}')
-            continue
         if not expected_group_version:
             expected_group_version = packages_file.packages[p].version
         elif packages_file.packages[p].version != expected_group_version:
             print(f'{p} in {group.packages[0]} does not match expected version {expected_group_version}', file=sys.stderr)
             exit(2)
-        if not expected_group_version:
-            import pdb; pdb.set_trace()
     if expected_group_version:
         package_ver, package_inc = expected_group_version.split('-')
         group.version_spec = f'{package_ver}-*'
+    group.packages.insert(0, group.source_package)
 
 print(f'name: ignition_{IGNITION_SUITE}_{OS}_{DISTRO}')
 print(f'method: {TARGET_REPO}')
@@ -100,11 +86,18 @@ print(f'suites: [{DISTRO}]')
 print('component: main')
 print('architectures: [amd64, i386, armhf, arm64, source]')
 print('filter_formula: "\\')
-import pdb; pdb.set_trace()
-for pgroup in PACKAGES:
+printable_groups = [pgroup for pgroup in PACKAGES if pgroup.version_spec]
+for idx in range(0, len(printable_groups)):
+    pgroup = printable_groups[idx]
     if not pgroup.version_spec:
         continue
-    print('((', end='')
-    '|\\\n'.join(f'Package (= {pkg})' for pkg in pgroup.packages)
-    print(f'), $Version (% {pgroup.version_spec}))')
+    print('(', end='')
+    print(' |\\\n '.join(f'(Package (= {name})' for name in pgroup.packages))
+    #'|\\\n'.join(f'Package (= x{name})' for name in pgroup.packages)
+    print(f'), $Version (% {pgroup.version_spec})', end='')
+    if idx != len(printable_groups) - 1:
+        print(' |\\')
+    else:
+        print(' \\\n"')
+
 

--- a/scripts/generate_ignition_import_config.py
+++ b/scripts/generate_ignition_import_config.py
@@ -100,7 +100,8 @@ for idx in range(0, len(printable_groups)):
     if not pgroup.version_spec:
         continue
     print('(', end='')
-    print(' |\\\n '.join(f'Package (= {name})' for name in pgroup.packages))
+    print(' |\\\n '.join(f'Package (= {name})' for name in pgroup.packages), end='')
+    print(' \\')
     print(f'), $Version (% {pgroup.version_spec})', end='')
     if idx != len(printable_groups) - 1:
         print(' |\\')

--- a/scripts/generate_ignition_import_config.py
+++ b/scripts/generate_ignition_import_config.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+import urllib.request
+import sys
+
+from dataclasses import dataclass
+from typing import List, Union
+
+
+@dataclass
+class Package:
+    name: str
+    version: str
+
+class PackagesFile:
+    def __init__(self, file_contents):
+        self.packages = dict()
+        current_package = None
+        for line in file_contents.splitlines():
+            if line.startswith('Version: '):
+                assert current_package
+                _, version = line.split(': ')
+                self.packages[current_package] = Package(current_package, version)
+            if line.startswith('Package: '):
+                _, current_package = line.split(': ')
+
+
+@dataclass
+class PackageGroup:
+    source_package: str
+    packages: None|List[str]
+    version_spec: str|None
+
+IGNITION_SUITE='fortress'
+
+PACKAGES = [
+        PackageGroup((f'ignition-{IGNITION_SUITE}',), version_spec=None),
+        PackageGroup(('ignition-cmake2', 'libignition-cmake2', 'libignition-cmake2-dev'), version_spec=None),
+        PackageGroup(('ignition-fuel-tools7', 'libignition-fuel-tools7', 'libignition-fuel-tools7-dev'), version_spec=None),
+        PackageGroup(('ignition-gazebo6', 'libignition-gazebo6', 'libignition-gazebo6-dev', 'libignition-gazebo6-plugins'), version_spec=None),
+        PackageGroup(('ignition-gui6', 'libignition-gui6', 'libignition-gui6-dev'), version_spec=None),
+        PackageGroup(('ignition-launch5', 'libignition-launch5', 'libignition-launch5-dev'), version_spec=None),
+        PackageGroup(('ignition-math6', 'libignition-math6', 'libignition-math6-dbg', 'libignition-math6-dev', 'libignition-math6-eigen-dev', 'python3-ignition-math6', 'ruby-ignition-math6'), version_spec=None),
+        PackageGroup(('ignition-msgs8', 'libignition-msgs8', 'libignition-msgs8-dev', 'libignition-msgs8-dbg'), version_spec=None),
+        PackageGroup(('ignition-physics5',  'libignition-physics5', 'libignition-physics5-bullet','libignition-physics5-bullet-dev',
+            'libignition-physics5-core-dev', 'libignition-physics5-dartsim', 'libignition-physics5-dartsim-dev',
+            'libignition-physics5-dev', 'libignition-heightmap-dev', 'libignition-physics5-mesh-dev', 'libignition-physics5-sdf-dev',
+            'libignition-physics5-tpe', 'libignition-physics5-tpe-dev', 'libignition-physics5-tpelib', 'libignition-physics5-tpelib-dev'
+            ), version_spec=None),
+        PackageGroup(('ignition-rendering6', 'libignition-rendering6', 'libignition-rendering6-core-dev',
+            'libignition-rendering6-dev', 'libignition-rendering6-ogre1', 'libignition-rendering6-ogre1-dev',
+            'libignition-rendering6-ogre2', 'libignition-rendering6-ogre2-dev'), version_spec=None),
+        PackageGroup(('ignition-sensors6', 'libignition-sensors6', 'libignition-sensors6-air-pressure', 'libignition-sensors6-air-pressure-dev',
+            'libignition-sensors6-altimeter', 'libignition-sensors6-altimeter-dev', 'libignition-sensors6-camera', 'libignition-sensors6-camera-dev',
+            'libignition-sensors6-depth-camera', 'libignition-sensors6-depth-camera-dev' 'libignition-sensors6-dev',
+            'libignition-sensors6-force-torque', 'libignition-sensors6-force-torque-dev', 'libignition-gpu-lidar', 'libignition-gpu-lidar-dev',
+            'libignition-imu', 'libignition-imu-dev', 'libignition-sensors6-lidar', 'libignition-sensors6-lidar-dev',
+            'libignition-sensors6-logical-camera', 'libignition-sensors6-logical-camera-dev',
+            'libignition-sensors6-magnetometer', 'libignition-sensors6-magnetometer-dev', 
+            'libignition-sensors6-rendering', 'libignition-sensors6-rendering-dev', 
+            'libignition-sensors6-rgbd-camera', 'libignition-sensors6-rgbd-camera-dev', 
+            'libignition-sensors6-segmentation-camera', 'libignition-sensors6-segmentation-camera-dev', 
+            'libignition-sensors6-thermal-camera', 'libignition-sensors6-thermal-camera-dev'
+            ), version_spec=None),
+        PackageGroup(('ignition-transport11', 'libignition-transport11', 'libignition-transport11-core-dev',
+            'libignition-transport11-dbg', 'libignition-transport11-dev',
+            'libignition-transport11-log', 'libignition-transport11-log-dev'), version_spec=None),
+        PackageGroup(('ogre-2.2', 'libogre-2.2', 'libogre-2.2-dev'), version_spec=None),
+        PackageGroup(('sdformat12', 'libsdformat12', 'libsdformat12-dbg', 'libsdformat12-dev', 'sdformat12-doc', 'sdformat12-sdf'), version_spec=None),
+        ]
+
+OS = 'ubuntu'
+TARGET_REPO = f'http://packages.osrfoundation.org/gazebo/{OS}-stable'
+DISTS = ('focal', 'jammy')
+DISTRO = DISTS[1]
+
+resp = urllib.request.urlopen(f'{TARGET_REPO}/dists/{DISTRO}/main/binary-amd64/Packages')
+packages_file = PackagesFile(resp.read().decode())
+
+for group in PACKAGES:
+    expected_group_version = None
+    for p in group.packages:
+        if p not in packages_file.packages:
+            print(f'Binary package {p} not found in {TARGET_REPO}')
+            continue
+        if not expected_group_version:
+            expected_group_version = packages_file.packages[p].version
+        elif packages_file.packages[p].version != expected_group_version:
+            print(f'{p} in {group.packages[0]} does not match expected version {expected_group_version}', file=sys.stderr)
+            exit(2)
+        if not expected_group_version:
+            import pdb; pdb.set_trace()
+    if expected_group_version:
+        package_ver, package_inc = expected_group_version.split('-')
+        group.version_spec = f'{package_ver}-*'
+
+print(f'name: ignition_{IGNITION_SUITE}_{OS}_{DISTRO}')
+print(f'method: {TARGET_REPO}')
+print(f'suites: [{DISTRO}]')
+print('component: main')
+print('architectures: [amd64, i386, armhf, arm64, source]')
+print('filter_formula: "\\')
+import pdb; pdb.set_trace()
+for pgroup in PACKAGES:
+    if not pgroup.version_spec:
+        continue
+    print('((', end='')
+    '|\\\n'.join(f'Package (= {pkg})' for pkg in pgroup.packages)
+    print(f'), $Version (% {pgroup.version_spec}))')
+

--- a/scripts/generate_ignition_import_config.py
+++ b/scripts/generate_ignition_import_config.py
@@ -58,10 +58,10 @@ PACKAGES = [
         PackageGroup('sdformat12', packages=None, version_spec=None),
     ]
 
-OS = 'ubuntu'
+OS = 'debian'
 TARGET_REPO = f'http://packages.osrfoundation.org/gazebo/{OS}-stable'
-DISTS = ('focal', 'jammy')
-DISTRO = DISTS[1]
+DISTS = ('focal', 'jammy', 'bullseye', 'buster')
+DISTRO = DISTS[2]
 
 resp = urllib.request.urlopen(f'{TARGET_REPO}/dists/{DISTRO}/main/binary-amd64/Packages')
 packages_file = PackagesFile(resp.read().decode())
@@ -93,7 +93,6 @@ for idx in range(0, len(printable_groups)):
         continue
     print('(', end='')
     print(' |\\\n '.join(f'(Package (= {name})' for name in pgroup.packages))
-    #'|\\\n'.join(f'Package (= x{name})' for name in pgroup.packages)
     print(f'), $Version (% {pgroup.version_spec})', end='')
     if idx != len(printable_groups) - 1:
         print(' |\\')

--- a/scripts/generate_ignition_import_config.py
+++ b/scripts/generate_ignition_import_config.py
@@ -31,6 +31,8 @@ class PackagesFile:
                     current_source = None
                     current_version = None
                 current_package = line.split(': ')[1]
+        if current_package not in self.packages:
+            self.packages[current_package] = Package(current_package, current_source, current_version)
 
 
 @dataclass

--- a/scripts/generate_ignition_import_config.py
+++ b/scripts/generate_ignition_import_config.py
@@ -58,10 +58,10 @@ PACKAGES = [
         PackageGroup('sdformat12', packages=None, version_spec=None),
     ]
 
-OS = 'debian'
+OS = 'ubuntu'
 TARGET_REPO = f'http://packages.osrfoundation.org/gazebo/{OS}-stable'
 DISTS = ('focal', 'jammy', 'bullseye', 'buster')
-DISTRO = DISTS[2]
+DISTRO = DISTS[1]
 
 resp = urllib.request.urlopen(f'{TARGET_REPO}/dists/{DISTRO}/main/binary-amd64/Packages')
 packages_file = PackagesFile(resp.read().decode())


### PR DESCRIPTION
:construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: 

This is a work-in-progress!

:construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: :construction: 

This script reads data from the packages.osrfoundation.org repository and prints out a reprepro-updater import configuration.

*Caveats and addendums*

* Right now it only supports the `-stable` repositories, and has a set of packages that essentially hard-codes Ignition Fortress despite taking the `--ignition-suite` as an argument. 
* Another limitation is that it looks _only_ at the binary-amd64 package information so it implicitly assumes no disparities between architectures.
* The parsing of the Debian `Packages` file is extremely rudimentary but presently sufficient in order to avoid dependencies outside the Python standard library.

*But that's enough with the caveats, what cool things does it do?*

With a builtin list of igniton suite source packages, it will find group up all of the binary packages generated by that source and create a valid reprepro import configuration for use in the ros_bootstrap repository. This will make it much easier to keep the bootstrap repository in sync with the current releases from the packages.osrfoundation.org repository and could eventually be run out-of-tree as part of the upstream team's release automation.

#143 was created using early prototypes of this script and I have another branch which reformats the existing ignition configurations to conform to the same style so that I can use the diff between the manually created configs and the ones this script generates to refine and improve the script, and especially, add support for other Ignition suites.