### PR TITLE
Upgrade Edifice packages

### DIFF
--- a/config/ignition_citadel_gazebo11_debian_buster.yaml
+++ b/config/ignition_citadel_gazebo11_debian_buster.yaml
@@ -14,7 +14,7 @@ Package (% =libgazebo11-dev)), \
 $Version (% 11.9.0-1~*)) |\
 ((Package (% =ignition-cmake2) |\
 Package (% =libignition-cmake2-dev)), \
-$Version (% 2.9.0-1~*)) |\
+$Version (% 2.11.0-1~*)) |\
 (Package (% =ignition-citadel), $Version (% 1.0.2*))|\
 ((Package (% =ignition-common3) |\
 Package (% =libignition-common3) |\
@@ -51,7 +51,7 @@ Package (% =libignition-math6) |\
 Package (% =libignition-math6-dbg) |\
 Package (% =libignition-math6-dev) |\
 Package (% =libignition-math6-eigen3-dev)), \
-$Version (% 6.9.2-1~*)) |\
+$Version (% 6.10.0-1~*)) |\
 ((Package (% =ignition-msgs5) |\
 Package (% =libignition-msgs5) |\
 Package (% =libignition-msgs5-dev) |\

--- a/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
+++ b/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
@@ -14,7 +14,7 @@ Package (% =libgazebo11-dev)), \
 $Version (% 11.9.0-1~*)) |\
 ((Package (% =ignition-cmake2) |\
 Package (% =libignition-cmake2-dev)), \
-$Version (% 2.9.0-1~*)) |\
+$Version (% 2.11.0-1~*)) |\
 (Package (% =ignition-citadel), $Version (% 1.0.2*))|\
 ((Package (% =ignition-common3) |\
 Package (% =libignition-common3) |\
@@ -51,7 +51,7 @@ Package (% =libignition-math6) |\
 Package (% =libignition-math6-dbg) |\
 Package (% =libignition-math6-dev) |\
 Package (% =libignition-math6-eigen3-dev)), \
-$Version (% 6.9.2-1~*)) |\
+$Version (% 6.10.0-1~*)) |\
 ((Package (% =ignition-msgs5) |\
 Package (% =libignition-msgs5) |\
 Package (% =libignition-msgs5-dev) |\

--- a/config/ignition_edifice_debian_buster.yaml
+++ b/config/ignition_edifice_debian_buster.yaml
@@ -16,21 +16,21 @@ Package (% =libignition-common4-graphics) |\
 Package (% =libignition-common4-graphics-dev) |\
 Package (% =libignition-common4-profiler) |\
 Package (% =libignition-common4-profiler-dev)), \
-$Version (% 4.4.0-*)) |\
-(Package (% =ignition-edifice), $Version (% 1.0.2-*)) |\
+$Version (% 4.5.0-*)) |\
+(Package (% =ignition-edifice), $Version (% 1.0.3-*)) |\
 ((Package (% =ignition-fuel-tools6) |\
 Package (% =libignition-fuel-tools6) |\
 Package (% =libignition-fuel-tools6-dev)), \
-$Version (% 6.1.0-*)) |\
+$Version (% 6.10.0-*)) |\
 ((Package (% =ignition-gazebo5) |\
 Package (% =libignition-gazebo5) |\
 Package (% =libignition-gazebo5-dev) |\
 Package (% =libignition-gazebo5-plugins)), \
-$Version (% 5.3.0-*)) |\
+$Version (% 5.4.0-*)) |\
 ((Package (% =ignition-gui5) |\
 Package (% libignition-gui5) |\
 Package (% libignition-gui5-dev)), \
-$Version (% 5.3.0-*)) |\
+$Version (% 5.5.0-*)) |\
 ((Package (% =ignition-launch4) |\
 Package (% =libignition-launch4) |\
 Package (% =libignition-launch4-dev)), \
@@ -39,7 +39,7 @@ $Version (% 4.1.0-*)) |\
 Package (% =libignition-msgs7) |\
 Package (% =libignition-msgs7-dev) |\
 Package (% =libignition-msgs7-dbg)), \
-$Version (% 7.2.0-*)) |\
+$Version (% 7.3.0-*)) |\
 ((Package (% =ignition-physics4) |\
 Package (% libignition-physics4) |\
 Package (% libignition-physics4-bullet-dev) |\
@@ -64,7 +64,7 @@ Package (% =libignition-rendering5-ogre1) |\
 Package (% =libignition-rendering5-ogre1-dev) |\
 Package (% =libignition-rendering5-ogre2) |\
 Package (% =libignition-rendering5-ogre2-dev)), \
-$Version (% 5.2.0-*)) |\
+$Version (% 5.2.1-*)) |\
 ((Package (% =ignition-sensors5) |\
 Package (% =libignition-sensors5) |\
 Package (% =libignition-sensors5-air-pressure) |\
@@ -93,7 +93,7 @@ Package (% =libignition-sensors5-rgbd-camera) |\
 Package (% =libignition-sensors5-rgbd-camera-dev) |\
 Package (% =libignition-sensors5-thermal-camera) |\
 Package (% =libignition-sensors5-thermal-camera-dev)), \
-$Version (% 5.1.0-*)) |\
+$Version (% 5.1.1-*)) |\
 ((Package (% =ignition-transport10) |\
 Package (% =libignition-transport10) |\
 Package (% libignition-transport10-core-dev) |\
@@ -101,7 +101,7 @@ Package (% libignition-transport10-dbg) |\
 Package (% libignition-transport10-dev) |\
 Package (% libignition-transport10-log) |\
 Package (% libignition-transport10-log-dev)), \
-$Version (% 10.1.0-*)) |\
+$Version (% 10.2.0-*)) |\
 ((Package (% =ignition-utils1) |\
 Package (% libignition-utils1) |\
 Package (% libignition-utils1-core-dev) |\
@@ -109,12 +109,12 @@ Package (% libignition-utils1-dbg) |\
 Package (% libignition-utils1-dev) |\
 Package (% libignition-utils1-cli) |\
 Package (% libignition-utils1-cli-dev)), \
-$Version (% 1.1.0-*)) |\
+$Version (% 1.4.0-*)) |\
 ((Package (% =sdformat11) |\
 Package (% =libsdformat11) |\
 Package (% =libsdformat11-dbg) |\
 Package (% =libsdformat11-dev) |\
 Package (% =sdformat11-doc) |\
 Package (% =sdformat11-sdf)), \
-$Version (% 11.3.0-*)) \
+$Version (% 11.4.1-*)) \
 "

--- a/config/ignition_edifice_ubuntu_focal.yaml
+++ b/config/ignition_edifice_ubuntu_focal.yaml
@@ -16,21 +16,21 @@ Package (% =libignition-common4-graphics) |\
 Package (% =libignition-common4-graphics-dev) |\
 Package (% =libignition-common4-profiler) |\
 Package (% =libignition-common4-profiler-dev)), \
-$Version (% 4.4.0-*)) |\
-(Package (% =ignition-edifice), $Version (% 1.0.2-*)) |\
+$Version (% 4.5.0-*)) |\
+(Package (% =ignition-edifice), $Version (% 1.0.3-*)) |\
 ((Package (% =ignition-fuel-tools6) |\
 Package (% =libignition-fuel-tools6) |\
 Package (% =libignition-fuel-tools6-dev)), \
-$Version (% 6.1.0-*)) |\
+$Version (% 6.10.0-*)) |\
 ((Package (% =ignition-gazebo5) |\
 Package (% =libignition-gazebo5) |\
 Package (% =libignition-gazebo5-dev) |\
 Package (% =libignition-gazebo5-plugins)), \
-$Version (% 5.3.0-*)) |\
+$Version (% 5.4.0-*)) |\
 ((Package (% =ignition-gui5) |\
 Package (% libignition-gui5) |\
 Package (% libignition-gui5-dev)), \
-$Version (% 5.3.0-*)) |\
+$Version (% 5.5.0-*)) |\
 ((Package (% =ignition-launch4) |\
 Package (% =libignition-launch4) |\
 Package (% =libignition-launch4-dev)), \
@@ -39,7 +39,7 @@ $Version (% 4.1.0-*)) |\
 Package (% =libignition-msgs7) |\
 Package (% =libignition-msgs7-dev) |\
 Package (% =libignition-msgs7-dbg)), \
-$Version (% 7.2.0-*)) |\
+$Version (% 7.3.0-*)) |\
 ((Package (% =ignition-physics4) |\
 Package (% libignition-physics4) |\
 Package (% libignition-physics4-bullet-dev) |\
@@ -64,7 +64,7 @@ Package (% =libignition-rendering5-ogre1) |\
 Package (% =libignition-rendering5-ogre1-dev) |\
 Package (% =libignition-rendering5-ogre2) |\
 Package (% =libignition-rendering5-ogre2-dev)), \
-$Version (% 5.2.0-*)) |\
+$Version (% 5.2.1-*)) |\
 ((Package (% =ignition-sensors5) |\
 Package (% =libignition-sensors5) |\
 Package (% =libignition-sensors5-air-pressure) |\
@@ -93,7 +93,7 @@ Package (% =libignition-sensors5-rgbd-camera) |\
 Package (% =libignition-sensors5-rgbd-camera-dev) |\
 Package (% =libignition-sensors5-thermal-camera) |\
 Package (% =libignition-sensors5-thermal-camera-dev)), \
-$Version (% 5.1.0-*)) |\
+$Version (% 5.1.1-*)) |\
 ((Package (% =ignition-transport10) |\
 Package (% =libignition-transport10) |\
 Package (% libignition-transport10-core-dev) |\
@@ -101,7 +101,7 @@ Package (% libignition-transport10-dbg) |\
 Package (% libignition-transport10-dev) |\
 Package (% libignition-transport10-log) |\
 Package (% libignition-transport10-log-dev)), \
-$Version (% 10.1.0-*)) |\
+$Version (% 10.2.0-*)) |\
 ((Package (% =ignition-utils1) |\
 Package (% libignition-utils1) |\
 Package (% libignition-utils1-core-dev) |\
@@ -109,12 +109,12 @@ Package (% libignition-utils1-dbg) |\
 Package (% libignition-utils1-dev) |\
 Package (% libignition-utils1-cli) |\
 Package (% libignition-utils1-cli-dev)), \
-$Version (% 1.1.0-*)) |\
+$Version (% 1.4.0-*)) |\
 ((Package (% =sdformat11) |\
 Package (% =libsdformat11) |\
 Package (% =libsdformat11-dbg) |\
 Package (% =libsdformat11-dev) |\
 Package (% =sdformat11-doc) |\
 Package (% =sdformat11-sdf)), \
-$Version (% 11.3.0-*)) \
+$Version (% 11.4.1-*)) \
 "


### PR DESCRIPTION
The last sync for Edifice, since it's now EOL.

* Similar to #131 
* Part of https://github.com/ignition-tooling/release-tools/issues/655

Note that I've also bumped `ign-cmake2` and `ign-math6`, which are still supported under Citadel, but are Edifice dependencies as well.