### PR TITLE
Update Ignition Edifice packages using generator script.

### DIFF
--- a/config/ignition_edifice_ubuntu_focal.yaml
+++ b/config/ignition_edifice_ubuntu_focal.yaml
@@ -5,7 +5,7 @@ component: main
 architectures: [amd64, armhf, arm64, source]
 filter_formula: "\
 (Package (= ignition-edifice)
-), $Version (% 1.0.2-*) |\
+), $Version (% 1.0.3-1*) |\
 (Package (= ignition-common4) |\
  Package (= libignition-common4) |\
  Package (= libignition-common4-av) |\
@@ -18,33 +18,33 @@ filter_formula: "\
  Package (= libignition-common4-graphics-dev) |\
  Package (= libignition-common4-profiler) |\
  Package (= libignition-common4-profiler-dev)
-), $Version (% 4.4.0-1*) |\
+), $Version (% 4.5.0-1*) |\
 (Package (= ignition-fuel-tools6) |\
  Package (= libignition-fuel-tools6) |\
  Package (= libignition-fuel-tools6-dev)
-), $Version (% 6.1.0-*) |\
+), $Version (% 6.2.0-1*) |\
 (Package (= ignition-gazebo5) |\
  Package (= libignition-gazebo5) |\
+ Package (= libignition-gazebo5-dbg) |\
  Package (= libignition-gazebo5-dev) |\
  Package (= libignition-gazebo5-plugins)
-), $Version (% 5.3.0-*) |\
+), $Version (% 5.4.0-1*) |\
 (Package (= ignition-gui5) |\
  Package (= libignition-gui5) |\
  Package (= libignition-gui5-dev)
-), $Version (% 5.3.0-*) |\
+), $Version (% 5.5.0-1*) |\
 (Package (= ignition-launch4) |\
  Package (= libignition-launch4) |\
  Package (= libignition-launch4-dev)
-), $Version (% 4.1.0-*) |\
+), $Version (% 4.1.0-1*) |\
 (Package (= ignition-msgs7) |\
  Package (= libignition-msgs7) |\
- Package (= libignition-msgs7-dev) |\
- Package (= libignition-msgs7-dbg)
-), $Version (% 7.2.0-*) |\
+ Package (= libignition-msgs7-dev)
+), $Version (% 7.3.0-1*) |\
 (Package (= ignition-physics4) |\
  Package (= libignition-physics4) |\
- Package (= libignition-physics4-bullet-dev) |\
  Package (= libignition-physics4-bullet) |\
+ Package (= libignition-physics4-bullet-dev) |\
  Package (= libignition-physics4-core-dev) |\
  Package (= libignition-physics4-dartsim) |\
  Package (= libignition-physics4-dartsim-dev) |\
@@ -56,7 +56,7 @@ filter_formula: "\
  Package (= libignition-physics4-tpe-dev) |\
  Package (= libignition-physics4-tpelib) |\
  Package (= libignition-physics4-tpelib-dev)
-), $Version (% 4.3.0-*) |\
+), $Version (% 4.3.0-1*) |\
 (Package (= ignition-rendering5) |\
  Package (= libignition-rendering5) |\
  Package (= libignition-rendering5-core-dev) |\
@@ -65,7 +65,7 @@ filter_formula: "\
  Package (= libignition-rendering5-ogre1-dev) |\
  Package (= libignition-rendering5-ogre2) |\
  Package (= libignition-rendering5-ogre2-dev)
-), $Version (% 5.2.0-*) |\
+), $Version (% 5.2.1-1*) |\
 (Package (= ignition-sensors5) |\
  Package (= libignition-sensors5) |\
  Package (= libignition-sensors5-air-pressure) |\
@@ -94,7 +94,7 @@ filter_formula: "\
  Package (= libignition-sensors5-rgbd-camera-dev) |\
  Package (= libignition-sensors5-thermal-camera) |\
  Package (= libignition-sensors5-thermal-camera-dev)
-), $Version (% 5.1.0-*) |\
+), $Version (% 5.1.1-1*) |\
 (Package (= ignition-transport10) |\
  Package (= libignition-transport10) |\
  Package (= libignition-transport10-core-dev) |\
@@ -102,20 +102,18 @@ filter_formula: "\
  Package (= libignition-transport10-dev) |\
  Package (= libignition-transport10-log) |\
  Package (= libignition-transport10-log-dev)
-), $Version (% 10.1.0-*) |\
+), $Version (% 10.2.0-1*) |\
 (Package (= ignition-utils1) |\
  Package (= libignition-utils1) |\
- Package (= libignition-utils1-core-dev) |\
+ Package (= libignition-utils1-cli-dev) |\
  Package (= libignition-utils1-dbg) |\
- Package (= libignition-utils1-dev) |\
- Package (= libignition-utils1-cli) |\
- Package (= libignition-utils1-cli-dev)
-), $Version (% 1.1.0-*) |\
+ Package (= libignition-utils1-dev)
+), $Version (% 1.4.0-1*) |\
 (Package (= sdformat11) |\
  Package (= libsdformat11) |\
  Package (= libsdformat11-dbg) |\
  Package (= libsdformat11-dev) |\
  Package (= sdformat11-doc) |\
  Package (= sdformat11-sdf)
-), $Version (% 11.3.0-*) \
+), $Version (% 11.4.1-1*) \
 "

--- a/config/ignition_edifice_ubuntu_focal.yaml
+++ b/config/ignition_edifice_ubuntu_focal.yaml
@@ -120,6 +120,13 @@ filter_formula: "\
  Package (= libignition-utils1-dbg) |\
  Package (= libignition-utils1-dev) \
 ), $Version (% 1.4.0-1*) |\
+(Package (= ogre-2.2) |\
+ Package (= blender-ogrexml-2.2) |\
+ Package (= libogre-2.2) |\
+ Package (= libogre-2.2-dev) |\
+ Package (= ogre-2.2-doc) |\
+ Package (= ogre-2.2-tools) \
+), $Version (% 2.2.5+20210824~ec3f70c-4*) |\
 (Package (= sdformat11) |\
  Package (= libsdformat11) |\
  Package (= libsdformat11-dbg) |\

--- a/config/ignition_edifice_ubuntu_focal.yaml
+++ b/config/ignition_edifice_ubuntu_focal.yaml
@@ -6,6 +6,9 @@ architectures: [amd64, armhf, arm64, source]
 filter_formula: "\
 (Package (= ignition-edifice)
 ), $Version (% 1.0.3-1*) |\
+(Package (= ignition-cmake2) |\
+ Package (= libignition-cmake2-dev)
+), $Version (% 2.12.1-1*) |\
 (Package (= ignition-common4) |\
  Package (= libignition-common4) |\
  Package (= libignition-common4-av) |\
@@ -37,6 +40,14 @@ filter_formula: "\
  Package (= libignition-launch4) |\
  Package (= libignition-launch4-dev)
 ), $Version (% 4.1.0-1*) |\
+(Package (= ignition-math6) |\
+ Package (= libignition-math6) |\
+ Package (= libignition-math6-dbg) |\
+ Package (= libignition-math6-dev) |\
+ Package (= libignition-math6-eigen3-dev) |\
+ Package (= python3-ignition-math6) |\
+ Package (= ruby-ignition-math6)
+), $Version (% 6.10.0-1*) |\
 (Package (= ignition-msgs7) |\
  Package (= libignition-msgs7) |\
  Package (= libignition-msgs7-dev)

--- a/config/ignition_edifice_ubuntu_focal.yaml
+++ b/config/ignition_edifice_ubuntu_focal.yaml
@@ -2,119 +2,120 @@ name: ignition_edifice_ubuntu_focal
 method: http://packages.osrfoundation.org/gazebo/ubuntu-stable
 suites: [focal]
 component: main
-architectures: [amd64, i386, armhf, arm64, source]
+architectures: [amd64, armhf, arm64, source]
 filter_formula: "\
-((Package (% =ignition-common4) |\
-Package (% =libignition-common4) |\
-Package (% =libignition-common4-av) |\
-Package (% =libignition-common4-av-dev) |\
-Package (% =libignition-common4-core-dev) |\
-Package (% =libignition-common4-dev) |\
-Package (% =libignition-common4-events) |\
-Package (% =libignition-common4-events-dev) |\
-Package (% =libignition-common4-graphics) |\
-Package (% =libignition-common4-graphics-dev) |\
-Package (% =libignition-common4-profiler) |\
-Package (% =libignition-common4-profiler-dev)), \
-$Version (% 4.4.0-*)) |\
-(Package (% =ignition-edifice), $Version (% 1.0.2-*)) |\
-((Package (% =ignition-fuel-tools6) |\
-Package (% =libignition-fuel-tools6) |\
-Package (% =libignition-fuel-tools6-dev)), \
-$Version (% 6.1.0-*)) |\
-((Package (% =ignition-gazebo5) |\
-Package (% =libignition-gazebo5) |\
-Package (% =libignition-gazebo5-dev) |\
-Package (% =libignition-gazebo5-plugins)), \
-$Version (% 5.3.0-*)) |\
-((Package (% =ignition-gui5) |\
-Package (% libignition-gui5) |\
-Package (% libignition-gui5-dev)), \
-$Version (% 5.3.0-*)) |\
-((Package (% =ignition-launch4) |\
-Package (% =libignition-launch4) |\
-Package (% =libignition-launch4-dev)), \
-$Version (% 4.1.0-*)) |\
-((Package (% =ignition-msgs7) |\
-Package (% =libignition-msgs7) |\
-Package (% =libignition-msgs7-dev) |\
-Package (% =libignition-msgs7-dbg)), \
-$Version (% 7.2.0-*)) |\
-((Package (% =ignition-physics4) |\
-Package (% libignition-physics4) |\
-Package (% libignition-physics4-bullet-dev) |\
-Package (% libignition-physics4-bullet) |\
-Package (% libignition-physics4-core-dev) |\
-Package (% libignition-physics4-dartsim) |\
-Package (% libignition-physics4-dartsim-dev) |\
-Package (% libignition-physics4-dev) |\
-Package (% libignition-physics4-heightmap-dev) |\
-Package (% libignition-physics4-mesh-dev) |\
-Package (% libignition-physics4-sdf-dev) |\
-Package (% libignition-physics4-tpe) |\
-Package (% libignition-physics4-tpe-dev) |\
-Package (% libignition-physics4-tpelib) |\
-Package (% libignition-physics4-tpelib-dev)), \
-$Version (% 4.3.0-*)) |\
-((Package (% =ignition-rendering5) |\
-Package (% =libignition-rendering5) |\
-Package (% =libignition-rendering5-core-dev) |\
-Package (% =libignition-rendering5-dev) |\
-Package (% =libignition-rendering5-ogre1) |\
-Package (% =libignition-rendering5-ogre1-dev) |\
-Package (% =libignition-rendering5-ogre2) |\
-Package (% =libignition-rendering5-ogre2-dev)), \
-$Version (% 5.2.0-*)) |\
-((Package (% =ignition-sensors5) |\
-Package (% =libignition-sensors5) |\
-Package (% =libignition-sensors5-air-pressure) |\
-Package (% =libignition-sensors5-air-pressure-dev) |\
-Package (% =libignition-sensors5-altimeter) |\
-Package (% =libignition-sensors5-altimeter-dev) |\
-Package (% =libignition-sensors5-camera) |\
-Package (% =libignition-sensors5-camera-dev) |\
-Package (% =libignition-sensors5-core-dev) |\
-Package (% =libignition-sensors5-depth-camera) |\
-Package (% =libignition-sensors5-depth-camera-dev) |\
-Package (% =libignition-sensors5-dev) |\
-Package (% =libignition-sensors5-gpu-lidar) |\
-Package (% =libignition-sensors5-gpu-lidar-dev) |\
-Package (% =libignition-sensors5-imu) |\
-Package (% =libignition-sensors5-imu-dev) |\
-Package (% =libignition-sensors5-lidar) |\
-Package (% =libignition-sensors5-lidar-dev) |\
-Package (% =libignition-sensors5-logical-camera) |\
-Package (% =libignition-sensors5-logical-camera-dev) |\
-Package (% =libignition-sensors5-magnetometer) |\
-Package (% =libignition-sensors5-magnetometer-dev) |\
-Package (% =libignition-sensors5-rendering) |\
-Package (% =libignition-sensors5-rendering-dev) |\
-Package (% =libignition-sensors5-rgbd-camera) |\
-Package (% =libignition-sensors5-rgbd-camera-dev) |\
-Package (% =libignition-sensors5-thermal-camera) |\
-Package (% =libignition-sensors5-thermal-camera-dev)), \
-$Version (% 5.1.0-*)) |\
-((Package (% =ignition-transport10) |\
-Package (% =libignition-transport10) |\
-Package (% libignition-transport10-core-dev) |\
-Package (% libignition-transport10-dbg) |\
-Package (% libignition-transport10-dev) |\
-Package (% libignition-transport10-log) |\
-Package (% libignition-transport10-log-dev)), \
-$Version (% 10.1.0-*)) |\
-((Package (% =ignition-utils1) |\
-Package (% libignition-utils1) |\
-Package (% libignition-utils1-core-dev) |\
-Package (% libignition-utils1-dbg) |\
-Package (% libignition-utils1-dev) |\
-Package (% libignition-utils1-cli) |\
-Package (% libignition-utils1-cli-dev)), \
-$Version (% 1.1.0-*)) |\
-((Package (% =sdformat11) |\
-Package (% =libsdformat11) |\
-Package (% =libsdformat11-dbg) |\
-Package (% =libsdformat11-dev) |\
-Package (% =sdformat11-doc) |\
-Package (% =sdformat11-sdf)), \
-$Version (% 11.3.0-*)) \
+(Package (= ignition-edifice)
+), $Version (% 1.0.2-*) |\
+(Package (= ignition-common4) |\
+ Package (= libignition-common4) |\
+ Package (= libignition-common4-av) |\
+ Package (= libignition-common4-av-dev) |\
+ Package (= libignition-common4-core-dev) |\
+ Package (= libignition-common4-dev) |\
+ Package (= libignition-common4-events) |\
+ Package (= libignition-common4-events-dev) |\
+ Package (= libignition-common4-graphics) |\
+ Package (= libignition-common4-graphics-dev) |\
+ Package (= libignition-common4-profiler) |\
+ Package (= libignition-common4-profiler-dev)
+), $Version (% 4.4.0-1*) |\
+(Package (= ignition-fuel-tools6) |\
+ Package (= libignition-fuel-tools6) |\
+ Package (= libignition-fuel-tools6-dev)
+), $Version (% 6.1.0-*) |\
+(Package (= ignition-gazebo5) |\
+ Package (= libignition-gazebo5) |\
+ Package (= libignition-gazebo5-dev) |\
+ Package (= libignition-gazebo5-plugins)
+), $Version (% 5.3.0-*) |\
+(Package (= ignition-gui5) |\
+ Package (= libignition-gui5) |\
+ Package (= libignition-gui5-dev)
+), $Version (% 5.3.0-*) |\
+(Package (= ignition-launch4) |\
+ Package (= libignition-launch4) |\
+ Package (= libignition-launch4-dev)
+), $Version (% 4.1.0-*) |\
+(Package (= ignition-msgs7) |\
+ Package (= libignition-msgs7) |\
+ Package (= libignition-msgs7-dev) |\
+ Package (= libignition-msgs7-dbg)
+), $Version (% 7.2.0-*) |\
+(Package (= ignition-physics4) |\
+ Package (= libignition-physics4) |\
+ Package (= libignition-physics4-bullet-dev) |\
+ Package (= libignition-physics4-bullet) |\
+ Package (= libignition-physics4-core-dev) |\
+ Package (= libignition-physics4-dartsim) |\
+ Package (= libignition-physics4-dartsim-dev) |\
+ Package (= libignition-physics4-dev) |\
+ Package (= libignition-physics4-heightmap-dev) |\
+ Package (= libignition-physics4-mesh-dev) |\
+ Package (= libignition-physics4-sdf-dev) |\
+ Package (= libignition-physics4-tpe) |\
+ Package (= libignition-physics4-tpe-dev) |\
+ Package (= libignition-physics4-tpelib) |\
+ Package (= libignition-physics4-tpelib-dev)
+), $Version (% 4.3.0-*) |\
+(Package (= ignition-rendering5) |\
+ Package (= libignition-rendering5) |\
+ Package (= libignition-rendering5-core-dev) |\
+ Package (= libignition-rendering5-dev) |\
+ Package (= libignition-rendering5-ogre1) |\
+ Package (= libignition-rendering5-ogre1-dev) |\
+ Package (= libignition-rendering5-ogre2) |\
+ Package (= libignition-rendering5-ogre2-dev)
+), $Version (% 5.2.0-*) |\
+(Package (= ignition-sensors5) |\
+ Package (= libignition-sensors5) |\
+ Package (= libignition-sensors5-air-pressure) |\
+ Package (= libignition-sensors5-air-pressure-dev) |\
+ Package (= libignition-sensors5-altimeter) |\
+ Package (= libignition-sensors5-altimeter-dev) |\
+ Package (= libignition-sensors5-camera) |\
+ Package (= libignition-sensors5-camera-dev) |\
+ Package (= libignition-sensors5-core-dev) |\
+ Package (= libignition-sensors5-depth-camera) |\
+ Package (= libignition-sensors5-depth-camera-dev) |\
+ Package (= libignition-sensors5-dev) |\
+ Package (= libignition-sensors5-gpu-lidar) |\
+ Package (= libignition-sensors5-gpu-lidar-dev) |\
+ Package (= libignition-sensors5-imu) |\
+ Package (= libignition-sensors5-imu-dev) |\
+ Package (= libignition-sensors5-lidar) |\
+ Package (= libignition-sensors5-lidar-dev) |\
+ Package (= libignition-sensors5-logical-camera) |\
+ Package (= libignition-sensors5-logical-camera-dev) |\
+ Package (= libignition-sensors5-magnetometer) |\
+ Package (= libignition-sensors5-magnetometer-dev) |\
+ Package (= libignition-sensors5-rendering) |\
+ Package (= libignition-sensors5-rendering-dev) |\
+ Package (= libignition-sensors5-rgbd-camera) |\
+ Package (= libignition-sensors5-rgbd-camera-dev) |\
+ Package (= libignition-sensors5-thermal-camera) |\
+ Package (= libignition-sensors5-thermal-camera-dev)
+), $Version (% 5.1.0-*) |\
+(Package (= ignition-transport10) |\
+ Package (= libignition-transport10) |\
+ Package (= libignition-transport10-core-dev) |\
+ Package (= libignition-transport10-dbg) |\
+ Package (= libignition-transport10-dev) |\
+ Package (= libignition-transport10-log) |\
+ Package (= libignition-transport10-log-dev)
+), $Version (% 10.1.0-*) |\
+(Package (= ignition-utils1) |\
+ Package (= libignition-utils1) |\
+ Package (= libignition-utils1-core-dev) |\
+ Package (= libignition-utils1-dbg) |\
+ Package (= libignition-utils1-dev) |\
+ Package (= libignition-utils1-cli) |\
+ Package (= libignition-utils1-cli-dev)
+), $Version (% 1.1.0-*) |\
+(Package (= sdformat11) |\
+ Package (= libsdformat11) |\
+ Package (= libsdformat11-dbg) |\
+ Package (= libsdformat11-dev) |\
+ Package (= sdformat11-doc) |\
+ Package (= sdformat11-sdf)
+), $Version (% 11.3.0-*) \
 "

--- a/config/ignition_edifice_ubuntu_focal.yaml
+++ b/config/ignition_edifice_ubuntu_focal.yaml
@@ -4,10 +4,10 @@ suites: [focal]
 component: main
 architectures: [amd64, armhf, arm64, source]
 filter_formula: "\
-(Package (= ignition-edifice)
+(Package (= ignition-edifice) \
 ), $Version (% 1.0.3-1*) |\
 (Package (= ignition-cmake2) |\
- Package (= libignition-cmake2-dev)
+ Package (= libignition-cmake2-dev) \
 ), $Version (% 2.12.1-1*) |\
 (Package (= ignition-common4) |\
  Package (= libignition-common4) |\
@@ -20,25 +20,25 @@ filter_formula: "\
  Package (= libignition-common4-graphics) |\
  Package (= libignition-common4-graphics-dev) |\
  Package (= libignition-common4-profiler) |\
- Package (= libignition-common4-profiler-dev)
+ Package (= libignition-common4-profiler-dev) \
 ), $Version (% 4.5.0-1*) |\
 (Package (= ignition-fuel-tools6) |\
  Package (= libignition-fuel-tools6) |\
- Package (= libignition-fuel-tools6-dev)
+ Package (= libignition-fuel-tools6-dev) \
 ), $Version (% 6.2.0-1*) |\
 (Package (= ignition-gazebo5) |\
  Package (= libignition-gazebo5) |\
  Package (= libignition-gazebo5-dbg) |\
  Package (= libignition-gazebo5-dev) |\
- Package (= libignition-gazebo5-plugins)
+ Package (= libignition-gazebo5-plugins) \
 ), $Version (% 5.4.0-1*) |\
 (Package (= ignition-gui5) |\
  Package (= libignition-gui5) |\
- Package (= libignition-gui5-dev)
+ Package (= libignition-gui5-dev) \
 ), $Version (% 5.5.0-1*) |\
 (Package (= ignition-launch4) |\
  Package (= libignition-launch4) |\
- Package (= libignition-launch4-dev)
+ Package (= libignition-launch4-dev) \
 ), $Version (% 4.1.0-1*) |\
 (Package (= ignition-math6) |\
  Package (= libignition-math6) |\
@@ -46,11 +46,11 @@ filter_formula: "\
  Package (= libignition-math6-dev) |\
  Package (= libignition-math6-eigen3-dev) |\
  Package (= python3-ignition-math6) |\
- Package (= ruby-ignition-math6)
+ Package (= ruby-ignition-math6) \
 ), $Version (% 6.10.0-1*) |\
 (Package (= ignition-msgs7) |\
  Package (= libignition-msgs7) |\
- Package (= libignition-msgs7-dev)
+ Package (= libignition-msgs7-dev) \
 ), $Version (% 7.3.0-1*) |\
 (Package (= ignition-physics4) |\
  Package (= libignition-physics4) |\
@@ -66,7 +66,7 @@ filter_formula: "\
  Package (= libignition-physics4-tpe) |\
  Package (= libignition-physics4-tpe-dev) |\
  Package (= libignition-physics4-tpelib) |\
- Package (= libignition-physics4-tpelib-dev)
+ Package (= libignition-physics4-tpelib-dev) \
 ), $Version (% 4.3.0-1*) |\
 (Package (= ignition-rendering5) |\
  Package (= libignition-rendering5) |\
@@ -75,7 +75,7 @@ filter_formula: "\
  Package (= libignition-rendering5-ogre1) |\
  Package (= libignition-rendering5-ogre1-dev) |\
  Package (= libignition-rendering5-ogre2) |\
- Package (= libignition-rendering5-ogre2-dev)
+ Package (= libignition-rendering5-ogre2-dev) \
 ), $Version (% 5.2.1-1*) |\
 (Package (= ignition-sensors5) |\
  Package (= libignition-sensors5) |\
@@ -104,7 +104,7 @@ filter_formula: "\
  Package (= libignition-sensors5-rgbd-camera) |\
  Package (= libignition-sensors5-rgbd-camera-dev) |\
  Package (= libignition-sensors5-thermal-camera) |\
- Package (= libignition-sensors5-thermal-camera-dev)
+ Package (= libignition-sensors5-thermal-camera-dev) \
 ), $Version (% 5.1.1-1*) |\
 (Package (= ignition-transport10) |\
  Package (= libignition-transport10) |\
@@ -112,19 +112,19 @@ filter_formula: "\
  Package (= libignition-transport10-dbg) |\
  Package (= libignition-transport10-dev) |\
  Package (= libignition-transport10-log) |\
- Package (= libignition-transport10-log-dev)
+ Package (= libignition-transport10-log-dev) \
 ), $Version (% 10.2.0-1*) |\
 (Package (= ignition-utils1) |\
  Package (= libignition-utils1) |\
  Package (= libignition-utils1-cli-dev) |\
  Package (= libignition-utils1-dbg) |\
- Package (= libignition-utils1-dev)
+ Package (= libignition-utils1-dev) \
 ), $Version (% 1.4.0-1*) |\
 (Package (= sdformat11) |\
  Package (= libsdformat11) |\
  Package (= libsdformat11-dbg) |\
  Package (= libsdformat11-dev) |\
  Package (= sdformat11-doc) |\
- Package (= sdformat11-sdf)
+ Package (= sdformat11-sdf) \
 ), $Version (% 11.4.1-1*) \
 "


### PR DESCRIPTION
This supersedes #145 which updates version numbers but does not actually match the current packages in the packages.osrfoundation.org repository.

The first commit on this PR, a3e52e855b395165396950a71180577a384e7d35 updates the format of the config file while not changing any contents so that it's easier to diff between the updated, generated content, and the previous content.

I recommend that reviewers use custom compare links to review the changes without formatting differences.
* [ubuntu_focal](https://github.com/ros-infrastructure/reprepro-updater/compare/dcacc2424401911524a379ed909b328d8f5755c5..nuclearsandwich/edifice-updates-2022-04-05#diff-9f768fbe2a06da79aae35728f17b7c509b43ed450effff17065caae1d7956a74)
* [debian_buster](https://github.com/ros-infrastructure/reprepro-updater/compare/d6c0870763c6555b9e9490a74a2733aeeda89876..nuclearsandwich/edifice-updates-2022-04-05#diff-fb26f866f50681cde8fb732babb3558d5b5a5e8d105616ec22593d05a92d8bb1)