### PR TITLE
Update aptly key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install aptly repo
         run: |
-            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ED75B5A4483DA07C
+            wget -qO - https://www.aptly.info/pubkey.txt | sudo apt-key add -
             sudo bash -c "echo 'deb http://repo.aptly.info/ squeeze main' > /etc/apt/sources.list.d/aptly.list"
       - name: Install software
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
             gpg --no-default-keyring --keyring /usr/share/keyrings/ubuntu-archive-keyring.gpg --export | gpg --no-default-keyring --keyring trustedkeys.gpg --import
             gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys 16E90B3FDF65EDE3AA7F323C04EE7237B7D453EC # Debian Stretch
             gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys 0146DC6D4A0B2914BDED34DB648ACFD622F3D138 # Debian Buster
-            gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys 0E98404D386FA1D9 # Debian Bullseye 
+            gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys 0E98404D386FA1D9 # Debian Bullseye
             gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys 67170598AF249743 # OSRF Repository
 
       - name: Generate key


### PR DESCRIPTION
Fetch via https rather than the keyserver network since the key appears to've changed since we last updated these scripts and this makes it robust to those changes as long as the aptly devs keep updating their https-hosted public key. Also, we've seen that the keyserver network is crumbling and this will probably be more reliable in general.