### PR TITLE
Update Fortress packages for Ubuntu Jammy.

### DIFF
--- a/config/ignition_fortress_ubuntu_jammy.yaml
+++ b/config/ignition_fortress_ubuntu_jammy.yaml
@@ -68,7 +68,7 @@ filter_formula: "\
  Package (= libignition-physics5-tpe-dev) |\
  Package (= libignition-physics5-tpelib) |\
  Package (= libignition-physics5-tpelib-dev) \
-), $Version (% 5.1.0+osrf-2*) |\
+), ($Version (% 5.1.0+osrf-2*) | $Version (% 5.1.0+osrf-3*)) |\
 (Package (= ignition-plugin) |\
  Package (= libignition-plugin) |\
  Package (= libignition-plugin-dbg) |\

--- a/config/ignition_fortress_ubuntu_jammy.yaml
+++ b/config/ignition_fortress_ubuntu_jammy.yaml
@@ -4,9 +4,43 @@ suites: [jammy]
 component: main
 architectures: [amd64, armhf, arm64, source]
 filter_formula: "\
+(Package (= ignition-fortress) \
+), $Version (% 1.0.3-1*) |\
 (Package (= ignition-cmake2) |\
  Package (= libignition-cmake2-dev) \
-), $Version (% 2.10.0-99*) |\
+), $Version (% 2.12.1-1*) |\
+(Package (= ignition-common4) |\
+ Package (= libignition-common4) |\
+ Package (= libignition-common4-av) |\
+ Package (= libignition-common4-av-dev) |\
+ Package (= libignition-common4-core-dev) |\
+ Package (= libignition-common4-dev) |\
+ Package (= libignition-common4-events) |\
+ Package (= libignition-common4-events-dev) |\
+ Package (= libignition-common4-graphics) |\
+ Package (= libignition-common4-graphics-dev) |\
+ Package (= libignition-common4-profiler) |\
+ Package (= libignition-common4-profiler-dev) \
+), $Version (% 4.5.0+osrf-1*) |\
+(Package (= ignition-fuel-tools7) |\
+ Package (= libignition-fuel-tools7) |\
+ Package (= libignition-fuel-tools7-dev) \
+), $Version (% 7.0.0+osrf-1*) |\
+(Package (= ignition-gazebo6) |\
+ Package (= libignition-gazebo6) |\
+ Package (= libignition-gazebo6-dbg) |\
+ Package (= libignition-gazebo6-dev) |\
+ Package (= libignition-gazebo6-plugins) |\
+ Package (= python3-ignition-gazebo6) \
+), $Version (% 6.9.0-1*) |\
+(Package (= ignition-gui6) |\
+ Package (= libignition-gui6) |\
+ Package (= libignition-gui6-dev) \
+), $Version (% 6.4.0-1*) |\
+(Package (= ignition-launch5) |\
+ Package (= libignition-launch5) |\
+ Package (= libignition-launch5-dev) \
+), $Version (% 5.1.0-1*) |\
 (Package (= ignition-math6) |\
  Package (= libignition-math6) |\
  Package (= libignition-math6-dbg) |\
@@ -14,5 +48,98 @@ filter_formula: "\
  Package (= libignition-math6-eigen3-dev) |\
  Package (= python3-ignition-math6) |\
  Package (= ruby-ignition-math6) \
-), $Version (% 6.10.0-99*) \
+), $Version (% 6.10.0-100*) |\
+(Package (= ignition-msgs8) |\
+ Package (= libignition-msgs8) |\
+ Package (= libignition-msgs8-dev) \
+), $Version (% 8.4.0-1*) |\
+(Package (= ignition-physics5) |\
+ Package (= libignition-physics5) |\
+ Package (= libignition-physics5-bullet) |\
+ Package (= libignition-physics5-bullet-dev) |\
+ Package (= libignition-physics5-core-dev) |\
+ Package (= libignition-physics5-dartsim) |\
+ Package (= libignition-physics5-dartsim-dev) |\
+ Package (= libignition-physics5-dev) |\
+ Package (= libignition-physics5-heightmap-dev) |\
+ Package (= libignition-physics5-mesh-dev) |\
+ Package (= libignition-physics5-sdf-dev) |\
+ Package (= libignition-physics5-tpe) |\
+ Package (= libignition-physics5-tpe-dev) |\
+ Package (= libignition-physics5-tpelib) |\
+ Package (= libignition-physics5-tpelib-dev) \
+), $Version (% 5.1.0+osrf-2*) |\
+(Package (= ignition-plugin) |\
+ Package (= libignition-plugin) |\
+ Package (= libignition-plugin-dbg) |\
+ Package (= libignition-plugin-dev) \
+), $Version (% 1.2.1+osrf-1*) |\
+(Package (= ignition-rendering6) |\
+ Package (= libignition-rendering6) |\
+ Package (= libignition-rendering6-core-dev) |\
+ Package (= libignition-rendering6-dev) |\
+ Package (= libignition-rendering6-ogre1) |\
+ Package (= libignition-rendering6-ogre1-dev) |\
+ Package (= libignition-rendering6-ogre2) |\
+ Package (= libignition-rendering6-ogre2-dev) \
+), $Version (% 6.3.1-1*) |\
+(Package (= ignition-sensors6) |\
+ Package (= libignition-sensors6) |\
+ Package (= libignition-sensors6-air-pressure) |\
+ Package (= libignition-sensors6-air-pressure-dev) |\
+ Package (= libignition-sensors6-altimeter) |\
+ Package (= libignition-sensors6-altimeter-dev) |\
+ Package (= libignition-sensors6-camera) |\
+ Package (= libignition-sensors6-camera-dev) |\
+ Package (= libignition-sensors6-core-dev) |\
+ Package (= libignition-sensors6-depth-camera) |\
+ Package (= libignition-sensors6-depth-camera-dev) |\
+ Package (= libignition-sensors6-dev) |\
+ Package (= libignition-sensors6-force-torque) |\
+ Package (= libignition-sensors6-force-torque-dev) |\
+ Package (= libignition-sensors6-gpu-lidar) |\
+ Package (= libignition-sensors6-gpu-lidar-dev) |\
+ Package (= libignition-sensors6-imu) |\
+ Package (= libignition-sensors6-imu-dev) |\
+ Package (= libignition-sensors6-lidar) |\
+ Package (= libignition-sensors6-lidar-dev) |\
+ Package (= libignition-sensors6-logical-camera) |\
+ Package (= libignition-sensors6-logical-camera-dev) |\
+ Package (= libignition-sensors6-magnetometer) |\
+ Package (= libignition-sensors6-magnetometer-dev) |\
+ Package (= libignition-sensors6-navsat) |\
+ Package (= libignition-sensors6-navsat-dev) |\
+ Package (= libignition-sensors6-rendering) |\
+ Package (= libignition-sensors6-rendering-dev) |\
+ Package (= libignition-sensors6-rgbd-camera) |\
+ Package (= libignition-sensors6-rgbd-camera-dev) |\
+ Package (= libignition-sensors6-segmentation-camera) |\
+ Package (= libignition-sensors6-segmentation-camera-dev) |\
+ Package (= libignition-sensors6-thermal-camera) |\
+ Package (= libignition-sensors6-thermal-camera-dev) \
+), $Version (% 6.3.0-2*) |\
+(Package (= ignition-tools) |\
+ Package (= libignition-tools-dev) \
+), $Version (% 1.4.1+osrf-1*) |\
+(Package (= ignition-transport11) |\
+ Package (= libignition-transport11) |\
+ Package (= libignition-transport11-core-dev) |\
+ Package (= libignition-transport11-dbg) |\
+ Package (= libignition-transport11-dev) |\
+ Package (= libignition-transport11-log) |\
+ Package (= libignition-transport11-log-dev) \
+), $Version (% 11.0.0+osrf-1*) |\
+(Package (= ignition-utils1) |\
+ Package (= libignition-utils1) |\
+ Package (= libignition-utils1-cli-dev) |\
+ Package (= libignition-utils1-dbg) |\
+ Package (= libignition-utils1-dev) \
+), $Version (% 1.4.0-1*) |\
+(Package (= sdformat12) |\
+ Package (= libsdformat12) |\
+ Package (= libsdformat12-dbg) |\
+ Package (= libsdformat12-dev) |\
+ Package (= sdformat12-doc) |\
+ Package (= sdformat12-sdf) \
+), $Version (% 12.4.0-1*) \
 "


### PR DESCRIPTION
According to the script which scraped packages.osrfoundation.org ogre-2.2 is missing. I know there were plans to make an ogre-next package available upstream in Ubuntu Jammy but I don't think those plans have progressed.

Created using the script in #144