### PR TITLE
Drop xenial and add jammy from import suites.

### DIFF
--- a/config/colcon.ubuntu.upstream.yaml
+++ b/config/colcon.ubuntu.upstream.yaml
@@ -1,6 +1,6 @@
 name: colcon
 method: https://packagecloud.io/dirk-thomas/colcon/ubuntu
-suites: [xenial, bionic, focal]
+suites: [bionic, focal, jammy]
 component: main
 architectures: [i386, amd64, armhf, arm64, source]
 filter_formula: "\


### PR DESCRIPTION
We noticed while debugging other issues that the Jammy repositories actually still include colcon-core 0.6.1.