### PR TITLE
Fortress missing boundingbox-camera package

### DIFF
--- a/config/ignition_fortress_ubuntu_jammy.yaml
+++ b/config/ignition_fortress_ubuntu_jammy.yaml
@@ -89,6 +89,8 @@ filter_formula: "\
  Package (= libignition-sensors6-air-pressure-dev) |\
  Package (= libignition-sensors6-altimeter) |\
  Package (= libignition-sensors6-altimeter-dev) |\
+ Package (= libignition-sensors6-boundingbox-camera) |\
+ Package (= libignition-sensors6-boundingbox-camera-dev) |\
  Package (= libignition-sensors6-camera) |\
  Package (= libignition-sensors6-camera-dev) |\
  Package (= libignition-sensors6-core-dev) |\


### PR DESCRIPTION
Almost there. Following #166
```
The following packages have unmet dependencies:
 libignition-gazebo6 : Depends: libignition-sensors6-boundingbox-camera (>= 6.6.0) but it is not installable
 libignition-gazebo6-plugins : Depends: libignition-sensors6-boundingbox-camera (>= 6.6.0) but it is not installable
 libignition-sensors6-dev : Depends: libignition-sensors6-boundingbox-camera-dev (= 6.6.0-2~jammy) but it is not installable
E: Unable to correct problems, you have held broken packages.
```