### PR TITLE
Import Fortress gz packages

### DIFF
--- a/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
+++ b/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
@@ -12,12 +12,25 @@ filter_formula: "\
  Package (= libgazebo11) |\
  Package (= libgazebo11-dev) \
 ), $Version (% 11.10.2-1*) |\
-(Package (= ignition-citadel) \
-), $Version (% 1.0.2-1*) |\
+(Package (= gz-citadel) \
+ Package (= ignition-citadel) |\
+), $Version (% 1.0.2-2*) |\
 (Package (= ignition-cmake2) |\
+ Package (= libgz-cmake2-dev) \
  Package (= libignition-cmake2-dev) \
-), $Version (% 2.12.1-1*) |\
+), $Version (% 2.14.0-2*) |\
 (Package (= ignition-common3) |\
+ Package (= libgz-common3) |\
+ Package (= libgz-common3-av) |\
+ Package (= libgz-common3-av-dev) |\
+ Package (= libgz-common3-core-dev) |\
+ Package (= libgz-common3-dev) |\
+ Package (= libgz-common3-events) |\
+ Package (= libgz-common3-events-dev) |\
+ Package (= libgz-common3-graphics) |\
+ Package (= libgz-common3-graphics-dev) |\
+ Package (= libgz-common3-profiler) |\
+ Package (= libgz-common3-profiler-dev) \
  Package (= libignition-common3) |\
  Package (= libignition-common3-av) |\
  Package (= libignition-common3-av-dev) |\
@@ -29,38 +42,67 @@ filter_formula: "\
  Package (= libignition-common3-graphics-dev) |\
  Package (= libignition-common3-profiler) |\
  Package (= libignition-common3-profiler-dev) \
-), $Version (% 3.14.0-1*) |\
+), $Version (% 3.14.2-1*) |\
 (Package (= ignition-fuel-tools4) |\
+ Package (= libgz-fuel-tools4) |\
+ Package (= libgz-fuel-tools4-dev) \
  Package (= libignition-fuel-tools4) |\
  Package (= libignition-fuel-tools4-dev) \
-), $Version (% 4.4.0-1*) |\
+), $Version (% 4.6.0-1*) |\
 (Package (= ignition-gazebo3) |\
+ Package (= libgz-sim3) |\
+ Package (= libgz-sim3-dbg) |\
+ Package (= libgz-sim3-dev) |\
+ Package (= libgz-sim3-plugins) \
  Package (= libignition-gazebo3) |\
  Package (= libignition-gazebo3-dbg) |\
  Package (= libignition-gazebo3-dev) |\
  Package (= libignition-gazebo3-plugins) \
-), $Version (% 3.13.0-1*) |\
+), $Version (% 3.14.0-1*) |\
 (Package (= ignition-gui3) |\
+ Package (= libgz-gui3) |\
+ Package (= libgz-gui3-dev) \
  Package (= libignition-gui3) |\
  Package (= libignition-gui3-dev) \
-), $Version (% 3.9.0-1*) |\
+), $Version (% 3.11.2-1*) |\
 (Package (= ignition-launch2) |\
+ Package (= libgz-launch2) |\
+ Package (= libgz-launch2-dev) \
  Package (= libignition-launch2) |\
  Package (= libignition-launch2-dev) \
-), $Version (% 2.2.2-1*) |\
+), $Version (% 2.3.0-1*) |\
 (Package (= ignition-math6) |\
+ Package (= libgz-math6) |\
+ Package (= libgz-math6-dbg) |\
+ Package (= libgz-math6-dev) |\
+ Package (= libgz-math6-eigen3-dev) |\
  Package (= libignition-math6) |\
  Package (= libignition-math6-dbg) |\
  Package (= libignition-math6-dev) |\
  Package (= libignition-math6-eigen3-dev) |\
+ Package (= python3-gz-math6) |\
  Package (= python3-ignition-math6) |\
+ Package (= ruby-gz-math6) \
  Package (= ruby-ignition-math6) \
-), $Version (% 6.10.0-1*) |\
+), $Version (% 6.12.0-2*) |\
 (Package (= ignition-msgs5) |\
+ Package (= libgz-msgs5) |\
+ Package (= libgz-msgs5-dev) \
  Package (= libignition-msgs5) |\
  Package (= libignition-msgs5-dev) \
-), $Version (% 5.9.0-1*) |\
+), $Version (% 5.10.0-4*) |\
 (Package (= ignition-physics2) |\
+ Package (= libgz-physics2) |\
+ Package (= libgz-physics2-core-dev) |\
+ Package (= libgz-physics2-dartsim) |\
+ Package (= libgz-physics2-dartsim-dev) |\
+ Package (= libgz-physics2-dev) |\
+ Package (= libgz-physics2-mesh-dev) |\
+ Package (= libgz-physics2-sdf-dev) |\
+ Package (= libgz-physics2-tpe) |\
+ Package (= libgz-physics2-tpe-dev) |\
+ Package (= libgz-physics2-tpelib) |\
+ Package (= libgz-physics2-tpelib-dev) \
  Package (= libignition-physics2) |\
  Package (= libignition-physics2-core-dev) |\
  Package (= libignition-physics2-dartsim) |\
@@ -72,13 +114,23 @@ filter_formula: "\
  Package (= libignition-physics2-tpe-dev) |\
  Package (= libignition-physics2-tpelib) |\
  Package (= libignition-physics2-tpelib-dev) \
-), $Version (% 2.5.0-1*) |\
+), $Version (% 2.5.1-1*) |\
 (Package (= ignition-plugin) |\
+ Package (= libgz-plugin) |\
+ Package (= libgz-plugin-dbg) |\
+ Package (= libgz-plugin-dev) \
  Package (= libignition-plugin) |\
  Package (= libignition-plugin-dbg) |\
  Package (= libignition-plugin-dev) \
-), $Version (% 1.2.1-1*) |\
+), $Version (% 1.3.0-1*) |\
 (Package (= ignition-rendering3) |\
+ Package (= libgz-rendering3) |\
+ Package (= libgz-rendering3-core-dev) |\
+ Package (= libgz-rendering3-dev) |\
+ Package (= libgz-rendering3-ogre1) |\
+ Package (= libgz-rendering3-ogre1-dev) |\
+ Package (= libgz-rendering3-ogre2) |\
+ Package (= libgz-rendering3-ogre2-dev) \
  Package (= libignition-rendering3) |\
  Package (= libignition-rendering3-core-dev) |\
  Package (= libignition-rendering3-dev) |\
@@ -86,8 +138,35 @@ filter_formula: "\
  Package (= libignition-rendering3-ogre1-dev) |\
  Package (= libignition-rendering3-ogre2) |\
  Package (= libignition-rendering3-ogre2-dev) \
-), $Version (% 3.6.0-1*) |\
+), $Version (% 3.6.0-4*) |\
 (Package (= ignition-sensors3) |\
+ Package (= libgz-sensors3) |\
+ Package (= libgz-sensors3-air-pressure) |\
+ Package (= libgz-sensors3-air-pressure-dev) |\
+ Package (= libgz-sensors3-altimeter) |\
+ Package (= libgz-sensors3-altimeter-dev) |\
+ Package (= libgz-sensors3-camera) |\
+ Package (= libgz-sensors3-camera-dev) |\
+ Package (= libgz-sensors3-core-dev) |\
+ Package (= libgz-sensors3-depth-camera) |\
+ Package (= libgz-sensors3-depth-camera-dev) |\
+ Package (= libgz-sensors3-dev) |\
+ Package (= libgz-sensors3-gpu-lidar) |\
+ Package (= libgz-sensors3-gpu-lidar-dev) |\
+ Package (= libgz-sensors3-imu) |\
+ Package (= libgz-sensors3-imu-dev) |\
+ Package (= libgz-sensors3-lidar) |\
+ Package (= libgz-sensors3-lidar-dev) |\
+ Package (= libgz-sensors3-logical-camera) |\
+ Package (= libgz-sensors3-logical-camera-dev) |\
+ Package (= libgz-sensors3-magnetometer) |\
+ Package (= libgz-sensors3-magnetometer-dev) |\
+ Package (= libgz-sensors3-rendering) |\
+ Package (= libgz-sensors3-rendering-dev) |\
+ Package (= libgz-sensors3-rgbd-camera) |\
+ Package (= libgz-sensors3-rgbd-camera-dev) |\
+ Package (= libgz-sensors3-thermal-camera) |\
+ Package (= libgz-sensors3-thermal-camera-dev) \
  Package (= libignition-sensors3) |\
  Package (= libignition-sensors3-air-pressure) |\
  Package (= libignition-sensors3-air-pressure-dev) |\
@@ -115,18 +194,26 @@ filter_formula: "\
  Package (= libignition-sensors3-rgbd-camera-dev) |\
  Package (= libignition-sensors3-thermal-camera) |\
  Package (= libignition-sensors3-thermal-camera-dev) \
-), $Version (% 3.3.0-1*) |\
-(Package (= ignition-tools) |\
+), $Version (% 3.4.0-1*) |\
+(Package (= gz-tools) |\
+ Package (= ignition-tools) \
+ Package (= libgz-tools-dev) \
  Package (= libignition-tools-dev) \
-), $Version (% 1.4.1-1*) |\
+), $Version (% 1.5.0-1*) |\
 (Package (= ignition-transport8) |\
+ Package (= libgz-transport8) |\
+ Package (= libgz-transport8-core-dev) |\
+ Package (= libgz-transport8-dbg) |\
+ Package (= libgz-transport8-dev) |\
+ Package (= libgz-transport8-log) |\
+ Package (= libgz-transport8-log-dev) \
  Package (= libignition-transport8) |\
  Package (= libignition-transport8-core-dev) |\
  Package (= libignition-transport8-dbg) |\
  Package (= libignition-transport8-dev) |\
  Package (= libignition-transport8-log) |\
  Package (= libignition-transport8-log-dev) \
-), $Version (% 8.2.1-1*) |\
+), $Version (% 8.3.0-2*) |\
 (Package (= ogre-2.1) |\
  Package (= blender-ogrexml-2.1) |\
  Package (= libogre-2.1) |\
@@ -140,5 +227,5 @@ filter_formula: "\
  Package (= libsdformat9-dev) |\
  Package (= sdformat9-doc) |\
  Package (= sdformat9-sdf) \
-), $Version (% 9.7.0-1*) \
+), $Version (% 9.8.0-1*) \
 "

--- a/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
+++ b/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
@@ -12,7 +12,7 @@ filter_formula: "\
  Package (= libgazebo11) |\
  Package (= libgazebo11-dev) \
 ), $Version (% 11.10.2-1*) |\
-(Package (= gz-citadel) \
+(Package (= gz-citadel) |\
  Package (= ignition-citadel) \
 ), $Version (% 1.0.2-2*) |\
 (Package (= ignition-cmake2) |\

--- a/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
+++ b/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
@@ -13,10 +13,10 @@ filter_formula: "\
  Package (= libgazebo11-dev) \
 ), $Version (% 11.10.2-1*) |\
 (Package (= gz-citadel) \
- Package (= ignition-citadel) |\
+ Package (= ignition-citadel) \
 ), $Version (% 1.0.2-2*) |\
 (Package (= ignition-cmake2) |\
- Package (= libgz-cmake2-dev) \
+ Package (= libgz-cmake2-dev) |\
  Package (= libignition-cmake2-dev) \
 ), $Version (% 2.14.0-2*) |\
 (Package (= ignition-common3) |\
@@ -30,7 +30,7 @@ filter_formula: "\
  Package (= libgz-common3-graphics) |\
  Package (= libgz-common3-graphics-dev) |\
  Package (= libgz-common3-profiler) |\
- Package (= libgz-common3-profiler-dev) \
+ Package (= libgz-common3-profiler-dev) |\
  Package (= libignition-common3) |\
  Package (= libignition-common3-av) |\
  Package (= libignition-common3-av-dev) |\
@@ -45,7 +45,7 @@ filter_formula: "\
 ), $Version (% 3.14.2-1*) |\
 (Package (= ignition-fuel-tools4) |\
  Package (= libgz-fuel-tools4) |\
- Package (= libgz-fuel-tools4-dev) \
+ Package (= libgz-fuel-tools4-dev) |\
  Package (= libignition-fuel-tools4) |\
  Package (= libignition-fuel-tools4-dev) \
 ), $Version (% 4.6.0-1*) |\
@@ -53,7 +53,7 @@ filter_formula: "\
  Package (= libgz-sim3) |\
  Package (= libgz-sim3-dbg) |\
  Package (= libgz-sim3-dev) |\
- Package (= libgz-sim3-plugins) \
+ Package (= libgz-sim3-plugins) |\
  Package (= libignition-gazebo3) |\
  Package (= libignition-gazebo3-dbg) |\
  Package (= libignition-gazebo3-dev) |\
@@ -61,13 +61,13 @@ filter_formula: "\
 ), $Version (% 3.14.0-1*) |\
 (Package (= ignition-gui3) |\
  Package (= libgz-gui3) |\
- Package (= libgz-gui3-dev) \
+ Package (= libgz-gui3-dev) |\
  Package (= libignition-gui3) |\
  Package (= libignition-gui3-dev) \
 ), $Version (% 3.11.2-1*) |\
 (Package (= ignition-launch2) |\
  Package (= libgz-launch2) |\
- Package (= libgz-launch2-dev) \
+ Package (= libgz-launch2-dev) |\
  Package (= libignition-launch2) |\
  Package (= libignition-launch2-dev) \
 ), $Version (% 2.3.0-1*) |\
@@ -82,12 +82,12 @@ filter_formula: "\
  Package (= libignition-math6-eigen3-dev) |\
  Package (= python3-gz-math6) |\
  Package (= python3-ignition-math6) |\
- Package (= ruby-gz-math6) \
+ Package (= ruby-gz-math6) |\
  Package (= ruby-ignition-math6) \
 ), $Version (% 6.12.0-2*) |\
 (Package (= ignition-msgs5) |\
  Package (= libgz-msgs5) |\
- Package (= libgz-msgs5-dev) \
+ Package (= libgz-msgs5-dev) |\
  Package (= libignition-msgs5) |\
  Package (= libignition-msgs5-dev) \
 ), $Version (% 5.10.0-4*) |\
@@ -102,7 +102,7 @@ filter_formula: "\
  Package (= libgz-physics2-tpe) |\
  Package (= libgz-physics2-tpe-dev) |\
  Package (= libgz-physics2-tpelib) |\
- Package (= libgz-physics2-tpelib-dev) \
+ Package (= libgz-physics2-tpelib-dev) |\
  Package (= libignition-physics2) |\
  Package (= libignition-physics2-core-dev) |\
  Package (= libignition-physics2-dartsim) |\
@@ -118,7 +118,7 @@ filter_formula: "\
 (Package (= ignition-plugin) |\
  Package (= libgz-plugin) |\
  Package (= libgz-plugin-dbg) |\
- Package (= libgz-plugin-dev) \
+ Package (= libgz-plugin-dev) |\
  Package (= libignition-plugin) |\
  Package (= libignition-plugin-dbg) |\
  Package (= libignition-plugin-dev) \
@@ -130,7 +130,7 @@ filter_formula: "\
  Package (= libgz-rendering3-ogre1) |\
  Package (= libgz-rendering3-ogre1-dev) |\
  Package (= libgz-rendering3-ogre2) |\
- Package (= libgz-rendering3-ogre2-dev) \
+ Package (= libgz-rendering3-ogre2-dev) |\
  Package (= libignition-rendering3) |\
  Package (= libignition-rendering3-core-dev) |\
  Package (= libignition-rendering3-dev) |\
@@ -166,7 +166,7 @@ filter_formula: "\
  Package (= libgz-sensors3-rgbd-camera) |\
  Package (= libgz-sensors3-rgbd-camera-dev) |\
  Package (= libgz-sensors3-thermal-camera) |\
- Package (= libgz-sensors3-thermal-camera-dev) \
+ Package (= libgz-sensors3-thermal-camera-dev) |\
  Package (= libignition-sensors3) |\
  Package (= libignition-sensors3-air-pressure) |\
  Package (= libignition-sensors3-air-pressure-dev) |\
@@ -196,8 +196,8 @@ filter_formula: "\
  Package (= libignition-sensors3-thermal-camera-dev) \
 ), $Version (% 3.4.0-1*) |\
 (Package (= gz-tools) |\
- Package (= ignition-tools) \
- Package (= libgz-tools-dev) \
+ Package (= ignition-tools) |\
+ Package (= libgz-tools-dev) |\
  Package (= libignition-tools-dev) \
 ), $Version (% 1.5.0-1*) |\
 (Package (= ignition-transport8) |\
@@ -206,7 +206,7 @@ filter_formula: "\
  Package (= libgz-transport8-dbg) |\
  Package (= libgz-transport8-dev) |\
  Package (= libgz-transport8-log) |\
- Package (= libgz-transport8-log-dev) \
+ Package (= libgz-transport8-log-dev) |\
  Package (= libignition-transport8) |\
  Package (= libignition-transport8-core-dev) |\
  Package (= libignition-transport8-dbg) |\

--- a/config/ignition_fortress_ubuntu_focal.yaml
+++ b/config/ignition_fortress_ubuntu_focal.yaml
@@ -116,10 +116,13 @@ filter_formula: "\
  Package (= libignition-physics5-tpelib-dev) \
 ), $Version (% 5.2.0-2*) |\
 (Package (= ignition-plugin) |\
+ Package (= libgz-plugin) |\
+ Package (= libgz-plugin-dbg) |\
+ Package (= libgz-plugin-dev) |\
  Package (= libignition-plugin) |\
  Package (= libignition-plugin-dbg) |\
  Package (= libignition-plugin-dev) \
-), $Version (% 1.2.1-1*) |\
+), $Version (% 1.3.0-1*) |\
 (Package (= ignition-rendering6) |\
  Package (= libgz-rendering6) |\
  Package (= libgz-rendering6-core-dev) |\

--- a/config/ignition_fortress_ubuntu_focal.yaml
+++ b/config/ignition_fortress_ubuntu_focal.yaml
@@ -50,7 +50,7 @@ filter_formula: "\
  Package (= libignition-gazebo6-dbg) |\
  Package (= libignition-gazebo6-dev) |\
  Package (= libignition-gazebo6-plugins) |\
- Package (= python3-gz-sim6) \
+ Package (= python3-gz-sim6) |\
  Package (= python3-ignition-gazebo6) \
 ), $Version (% 6.11.0-2*) |\
 (Package (= ignition-gui6) |\

--- a/config/ignition_fortress_ubuntu_focal.yaml
+++ b/config/ignition_fortress_ubuntu_focal.yaml
@@ -233,10 +233,6 @@ filter_formula: "\
  Package (= libignition-transport11-log-dev) \
 ), $Version (% 11.2.0-3*) |\
 (Package (= ignition-utils1) |\
- Package (= libgz-utils1) |\
- Package (= libgz-utils1-cli-dev) |\
- Package (= libgz-utils1-dbg) |\
- Package (= libgz-utils1-dev) |\
  Package (= libignition-utils1) |\
  Package (= libignition-utils1-cli-dev) |\
  Package (= libignition-utils1-dbg) |\

--- a/config/ignition_fortress_ubuntu_focal.yaml
+++ b/config/ignition_fortress_ubuntu_focal.yaml
@@ -211,9 +211,11 @@ filter_formula: "\
  Package (= libignition-sensors6-thermal-camera) |\
  Package (= libignition-sensors6-thermal-camera-dev) \
 ), $Version (% 6.6.0-3*) |\
-(Package (= ignition-tools) |\
+(Package (= gz-tools) |\
+ Package (= ignition-tools) |\
+ Package (= libgz-tools-dev) |\
  Package (= libignition-tools-dev) \
-), $Version (% 1.4.1-1*) |\
+), $Version (% 1.5.0-1*) |\
 (Package (= ignition-transport11) |\
  Package (= libgz-transport11) |\
  Package (= libgz-transport11-core-dev) |\

--- a/config/ignition_fortress_ubuntu_focal.yaml
+++ b/config/ignition_fortress_ubuntu_focal.yaml
@@ -6,9 +6,6 @@ architectures: [amd64, armhf, arm64, source]
 filter_formula: "\
 (Package (= ignition-fortress) \
 ), $Version (% 1.0.3-1*) |\
-(Package (= ignition-cmake2) |\
- Package (= libignition-cmake2-dev) \
-), $Version (% 2.12.1-1*) |\
 (Package (= ignition-common4) |\
  Package (= libignition-common4) |\
  Package (= libignition-common4-av) |\
@@ -41,14 +38,6 @@ filter_formula: "\
  Package (= libignition-launch5) |\
  Package (= libignition-launch5-dev) \
 ), $Version (% 5.1.0-1*) |\
-(Package (= ignition-math6) |\
- Package (= libignition-math6) |\
- Package (= libignition-math6-dbg) |\
- Package (= libignition-math6-dev) |\
- Package (= libignition-math6-eigen3-dev) |\
- Package (= python3-ignition-math6) |\
- Package (= ruby-ignition-math6) \
-), $Version (% 6.10.0-1*) |\
 (Package (= ignition-msgs8) |\
  Package (= libignition-msgs8) |\
  Package (= libignition-msgs8-dev) \
@@ -69,11 +58,6 @@ filter_formula: "\
  Package (= libignition-physics5-tpelib) |\
  Package (= libignition-physics5-tpelib-dev) \
 ), $Version (% 5.1.0-2*) |\
-(Package (= ignition-plugin) |\
- Package (= libignition-plugin) |\
- Package (= libignition-plugin-dbg) |\
- Package (= libignition-plugin-dev) \
-), $Version (% 1.2.1-1*) |\
 (Package (= ignition-rendering6) |\
  Package (= libignition-rendering6) |\
  Package (= libignition-rendering6-core-dev) |\
@@ -118,9 +102,6 @@ filter_formula: "\
  Package (= libignition-sensors6-thermal-camera) |\
  Package (= libignition-sensors6-thermal-camera-dev) \
 ), $Version (% 6.3.0-2*) |\
-(Package (= ignition-tools) |\
- Package (= libignition-tools-dev) \
-), $Version (% 1.4.1-1*) |\
 (Package (= ignition-transport11) |\
  Package (= libignition-transport11) |\
  Package (= libignition-transport11-core-dev) |\

--- a/config/ignition_fortress_ubuntu_focal.yaml
+++ b/config/ignition_fortress_ubuntu_focal.yaml
@@ -66,13 +66,19 @@ filter_formula: "\
  Package (= libignition-launch5-dev) \
 ), $Version (% 5.2.0-1*) |\
 (Package (= ignition-math6) |\
+ Package (= libgz-math6) |\
+ Package (= libgz-math6-dbg) |\
+ Package (= libgz-math6-dev) |\
+ Package (= libgz-math6-eigen-dev) |\
  Package (= libignition-math6) |\
  Package (= libignition-math6-dbg) |\
  Package (= libignition-math6-dev) |\
  Package (= libignition-math6-eigen3-dev) |\
+ Package (= python3-gz-math6) |\
  Package (= python3-ignition-math6) |\
+ Package (= ruby-gz-math6) |\
  Package (= ruby-ignition-math6) \
-), $Version (% 6.10.0-1*) |\
+), $Version (% 6.12.0-2*) |\
 (Package (= ignition-msgs8) |\
  Package (= libgz-msgs8) |\
  Package (= libgz-msgs8-dev) |\

--- a/config/ignition_fortress_ubuntu_focal.yaml
+++ b/config/ignition_fortress_ubuntu_focal.yaml
@@ -145,6 +145,8 @@ filter_formula: "\
  Package (= libgz-sensors6-air-pressure-dev) |\
  Package (= libgz-sensors6-altimeter) |\
  Package (= libgz-sensors6-altimeter-dev) |\
+ Package (= libgz-sensors6-boundingbox-camera) |\
+ Package (= libgz-sensors6-boundingbox-camera-dev) |\
  Package (= libgz-sensors6-camera) |\
  Package (= libgz-sensors6-camera-dev) |\
  Package (= libgz-sensors6-core-dev) |\
@@ -178,6 +180,8 @@ filter_formula: "\
  Package (= libignition-sensors6-air-pressure-dev) |\
  Package (= libignition-sensors6-altimeter) |\
  Package (= libignition-sensors6-altimeter-dev) |\
+ Package (= libignition-sensors6-boundingbox-camera) |\
+ Package (= libignition-sensors6-boundingbox-camera-dev) |\
  Package (= libignition-sensors6-camera) |\
  Package (= libignition-sensors6-camera-dev) |\
  Package (= libignition-sensors6-core-dev) |\

--- a/config/ignition_fortress_ubuntu_focal.yaml
+++ b/config/ignition_fortress_ubuntu_focal.yaml
@@ -69,7 +69,7 @@ filter_formula: "\
  Package (= libgz-math6) |\
  Package (= libgz-math6-dbg) |\
  Package (= libgz-math6-dev) |\
- Package (= libgz-math6-eigen-dev) |\
+ Package (= libgz-math6-eigen3-dev) |\
  Package (= libignition-math6) |\
  Package (= libignition-math6-dbg) |\
  Package (= libignition-math6-dev) |\
@@ -78,7 +78,7 @@ filter_formula: "\
  Package (= python3-ignition-math6) |\
  Package (= ruby-gz-math6) |\
  Package (= ruby-ignition-math6) \
-), $Version (% 6.12.0-2*) |\
+), $Version (% 6.12.0-3*) |\
 (Package (= ignition-msgs8) |\
  Package (= libgz-msgs8) |\
  Package (= libgz-msgs8-dev) |\

--- a/config/ignition_fortress_ubuntu_focal.yaml
+++ b/config/ignition_fortress_ubuntu_focal.yaml
@@ -8,8 +8,9 @@ filter_formula: "\
  Package (= ignition-fortress) \
 ), $Version (% 1.0.3-2*) |\
 (Package (= ignition-cmake2) |\
+ Package (= libgz-cmake2-dev) |\
  Package (= libignition-cmake2-dev) \
-), $Version (% 2.12.1-1*) |\
+), $Version (% 2.14.0-2*) |\
 (Package (= ignition-common4) |\
  Package (= libgz-common4) |\
  Package (= libgz-common4-av) |\

--- a/config/ignition_fortress_ubuntu_focal.yaml
+++ b/config/ignition_fortress_ubuntu_focal.yaml
@@ -217,6 +217,8 @@ filter_formula: "\
  Package (= libignition-tools-dev) \
 ), $Version (% 1.5.0-1*) |\
 (Package (= ignition-transport11) |\
+ Package (= gz-transport11-cli) |\
+ Package (= ignition-transport11-cli) |\
  Package (= libgz-transport11) |\
  Package (= libgz-transport11-core-dev) |\
  Package (= libgz-transport11-dbg) |\

--- a/config/ignition_fortress_ubuntu_focal.yaml
+++ b/config/ignition_fortress_ubuntu_focal.yaml
@@ -4,9 +4,21 @@ suites: [focal]
 component: main
 architectures: [amd64, armhf, arm64, source]
 filter_formula: "\
-(Package (= ignition-fortress) \
-), $Version (% 1.0.3-1*) |\
+(Package (= gz-fortress) |\
+ Package (= ignition-fortress) \
+), $Version (% 1.0.3-2*) |\
 (Package (= ignition-common4) |\
+ Package (= libgz-common4) |\
+ Package (= libgz-common4-av) |\
+ Package (= libgz-common4-av-dev) |\
+ Package (= libgz-common4-core-dev) |\
+ Package (= libgz-common4-dev) |\
+ Package (= libgz-common4-events) |\
+ Package (= libgz-common4-events-dev) |\
+ Package (= libgz-common4-graphics) |\
+ Package (= libgz-common4-graphics-dev) |\
+ Package (= libgz-common4-profiler) |\
+ Package (= libgz-common4-profiler-dev) |\
  Package (= libignition-common4) |\
  Package (= libignition-common4-av) |\
  Package (= libignition-common4-av-dev) |\
@@ -18,31 +30,58 @@ filter_formula: "\
  Package (= libignition-common4-graphics-dev) |\
  Package (= libignition-common4-profiler) |\
  Package (= libignition-common4-profiler-dev) \
-), $Version (% 4.5.0-1*) |\
+), $Version (% 4.5.2-1*) |\
 (Package (= ignition-fuel-tools7) |\
+ Package (= libgz-fuel-tools7) |\
+ Package (= libgz-fuel-tools7-dev) |\
  Package (= libignition-fuel-tools7) |\
  Package (= libignition-fuel-tools7-dev) \
-), $Version (% 7.0.0-1*) |\
+), $Version (% 7.1.0-1*) |\
 (Package (= ignition-gazebo6) |\
+ Package (= libgz-sim6) |\
+ Package (= libgz-sim6-dbg) |\
+ Package (= libgz-sim6-dev) |\
+ Package (= libgz-sim6-plugins) |\
  Package (= libignition-gazebo6) |\
  Package (= libignition-gazebo6-dbg) |\
  Package (= libignition-gazebo6-dev) |\
  Package (= libignition-gazebo6-plugins) |\
+ Package (= python3-gz-sim6) \
  Package (= python3-ignition-gazebo6) \
-), $Version (% 6.9.0-1*) |\
+), $Version (% 6.11.0-2*) |\
 (Package (= ignition-gui6) |\
+ Package (= libgz-gui6) |\
+ Package (= libgz-gui6-dev) |\
  Package (= libignition-gui6) |\
  Package (= libignition-gui6-dev) \
-), $Version (% 6.4.0-1*) |\
+), $Version (% 6.6.1-2*) |\
 (Package (= ignition-launch5) |\
+ Package (= libgz-launch5) |\
+ Package (= libgz-launch5-dev) |\
  Package (= libignition-launch5) |\
  Package (= libignition-launch5-dev) \
-), $Version (% 5.1.0-1*) |\
+), $Version (% 5.2.0-1*) |\
 (Package (= ignition-msgs8) |\
+ Package (= libgz-msgs8) |\
+ Package (= libgz-msgs8-dev) |\
  Package (= libignition-msgs8) |\
  Package (= libignition-msgs8-dev) \
-), $Version (% 8.4.0-1*) |\
+), $Version (% 8.6.0-3*) |\
 (Package (= ignition-physics5) |\
+ Package (= libgz-physics5) |\
+ Package (= libgz-physics5-bullet) |\
+ Package (= libgz-physics5-bullet-dev) |\
+ Package (= libgz-physics5-core-dev) |\
+ Package (= libgz-physics5-dartsim) |\
+ Package (= libgz-physics5-dartsim-dev) |\
+ Package (= libgz-physics5-dev) |\
+ Package (= libgz-physics5-heightmap-dev) |\
+ Package (= libgz-physics5-mesh-dev) |\
+ Package (= libgz-physics5-sdf-dev) |\
+ Package (= libgz-physics5-tpe) |\
+ Package (= libgz-physics5-tpe-dev) |\
+ Package (= libgz-physics5-tpelib) |\
+ Package (= libgz-physics5-tpelib-dev) |\
  Package (= libignition-physics5) |\
  Package (= libignition-physics5-bullet) |\
  Package (= libignition-physics5-bullet-dev) |\
@@ -57,8 +96,15 @@ filter_formula: "\
  Package (= libignition-physics5-tpe-dev) |\
  Package (= libignition-physics5-tpelib) |\
  Package (= libignition-physics5-tpelib-dev) \
-), $Version (% 5.1.0-2*) |\
+), $Version (% 5.2.0-2*) |\
 (Package (= ignition-rendering6) |\
+ Package (= libgz-rendering6) |\
+ Package (= libgz-rendering6-core-dev) |\
+ Package (= libgz-rendering6-dev) |\
+ Package (= libgz-rendering6-ogre1) |\
+ Package (= libgz-rendering6-ogre1-dev) |\
+ Package (= libgz-rendering6-ogre2) |\
+ Package (= libgz-rendering6-ogre2-dev) |\
  Package (= libignition-rendering6) |\
  Package (= libignition-rendering6-core-dev) |\
  Package (= libignition-rendering6-dev) |\
@@ -66,8 +112,41 @@ filter_formula: "\
  Package (= libignition-rendering6-ogre1-dev) |\
  Package (= libignition-rendering6-ogre2) |\
  Package (= libignition-rendering6-ogre2-dev) \
-), $Version (% 6.3.1-1*) |\
+), $Version (% 6.5.1-2*) |\
 (Package (= ignition-sensors6) |\
+ Package (= libgz-sensors6) |\
+ Package (= libgz-sensors6-air-pressure) |\
+ Package (= libgz-sensors6-air-pressure-dev) |\
+ Package (= libgz-sensors6-altimeter) |\
+ Package (= libgz-sensors6-altimeter-dev) |\
+ Package (= libgz-sensors6-camera) |\
+ Package (= libgz-sensors6-camera-dev) |\
+ Package (= libgz-sensors6-core-dev) |\
+ Package (= libgz-sensors6-depth-camera) |\
+ Package (= libgz-sensors6-depth-camera-dev) |\
+ Package (= libgz-sensors6-dev) |\
+ Package (= libgz-sensors6-force-torque) |\
+ Package (= libgz-sensors6-force-torque-dev) |\
+ Package (= libgz-sensors6-gpu-lidar) |\
+ Package (= libgz-sensors6-gpu-lidar-dev) |\
+ Package (= libgz-sensors6-imu) |\
+ Package (= libgz-sensors6-imu-dev) |\
+ Package (= libgz-sensors6-lidar) |\
+ Package (= libgz-sensors6-lidar-dev) |\
+ Package (= libgz-sensors6-logical-camera) |\
+ Package (= libgz-sensors6-logical-camera-dev) |\
+ Package (= libgz-sensors6-magnetometer) |\
+ Package (= libgz-sensors6-magnetometer-dev) |\
+ Package (= libgz-sensors6-navsat) |\
+ Package (= libgz-sensors6-navsat-dev) |\
+ Package (= libgz-sensors6-rendering) |\
+ Package (= libgz-sensors6-rendering-dev) |\
+ Package (= libgz-sensors6-rgbd-camera) |\
+ Package (= libgz-sensors6-rgbd-camera-dev) |\
+ Package (= libgz-sensors6-segmentation-camera) |\
+ Package (= libgz-sensors6-segmentation-camera-dev) |\
+ Package (= libgz-sensors6-thermal-camera) |\
+ Package (= libgz-sensors6-thermal-camera-dev) |\
  Package (= libignition-sensors6) |\
  Package (= libignition-sensors6-air-pressure) |\
  Package (= libignition-sensors6-air-pressure-dev) |\
@@ -101,21 +180,31 @@ filter_formula: "\
  Package (= libignition-sensors6-segmentation-camera-dev) |\
  Package (= libignition-sensors6-thermal-camera) |\
  Package (= libignition-sensors6-thermal-camera-dev) \
-), $Version (% 6.3.0-2*) |\
+), $Version (% 6.6.0-3*) |\
 (Package (= ignition-transport11) |\
+ Package (= libgz-transport11) |\
+ Package (= libgz-transport11-core-dev) |\
+ Package (= libgz-transport11-dbg) |\
+ Package (= libgz-transport11-dev) |\
+ Package (= libgz-transport11-log) |\
+ Package (= libgz-transport11-log-dev) |\
  Package (= libignition-transport11) |\
  Package (= libignition-transport11-core-dev) |\
  Package (= libignition-transport11-dbg) |\
  Package (= libignition-transport11-dev) |\
  Package (= libignition-transport11-log) |\
  Package (= libignition-transport11-log-dev) \
-), $Version (% 11.0.0-1*) |\
+), $Version (% 11.2.0-3*) |\
 (Package (= ignition-utils1) |\
+ Package (= libgz-utils1) |\
+ Package (= libgz-utils1-cli-dev) |\
+ Package (= libgz-utils1-dbg) |\
+ Package (= libgz-utils1-dev) |\
  Package (= libignition-utils1) |\
  Package (= libignition-utils1-cli-dev) |\
  Package (= libignition-utils1-dbg) |\
  Package (= libignition-utils1-dev) \
-), $Version (% 1.4.0-1*) |\
+), $Version (% 1.4.0-2*) |\
 (Package (= ogre-2.2) |\
  Package (= blender-ogrexml-2.2) |\
  Package (= libogre-2.2) |\
@@ -129,5 +218,5 @@ filter_formula: "\
  Package (= libsdformat12-dev) |\
  Package (= sdformat12-doc) |\
  Package (= sdformat12-sdf) \
-), $Version (% 12.4.0-1*) \
+), $Version (% 12.5.0-1*) \
 "

--- a/config/ignition_fortress_ubuntu_jammy.yaml
+++ b/config/ignition_fortress_ubuntu_jammy.yaml
@@ -21,7 +21,7 @@ filter_formula: "\
  Package (= libignition-common4-graphics-dev) |\
  Package (= libignition-common4-profiler) |\
  Package (= libignition-common4-profiler-dev) \
-), $Version (% 4.5.0+osrf-1*) |\
+), $Version (% 4.5.1-2*) |\
 (Package (= ignition-fuel-tools7) |\
  Package (= libignition-fuel-tools7) |\
  Package (= libignition-fuel-tools7-dev) \
@@ -36,7 +36,7 @@ filter_formula: "\
 (Package (= ignition-gui6) |\
  Package (= libignition-gui6) |\
  Package (= libignition-gui6-dev) \
-), $Version (% 6.4.0-1*) |\
+), $Version (% 6.6.0-1*) |\
 (Package (= ignition-launch5) |\
  Package (= libignition-launch5) |\
  Package (= libignition-launch5-dev) \
@@ -52,7 +52,7 @@ filter_formula: "\
 (Package (= ignition-msgs8) |\
  Package (= libignition-msgs8) |\
  Package (= libignition-msgs8-dev) \
-), $Version (% 8.4.0-1*) |\
+), $Version (% 8.6.0-1*) |\
 (Package (= ignition-physics5) |\
  Package (= libignition-physics5) |\
  Package (= libignition-physics5-bullet) |\
@@ -68,12 +68,12 @@ filter_formula: "\
  Package (= libignition-physics5-tpe-dev) |\
  Package (= libignition-physics5-tpelib) |\
  Package (= libignition-physics5-tpelib-dev) \
-), ($Version (% 5.1.0+osrf-2*) | $Version (% 5.1.0+osrf-3*)) |\
+), $Version (% 5.2.0-1*) |\
 (Package (= ignition-plugin) |\
  Package (= libignition-plugin) |\
  Package (= libignition-plugin-dbg) |\
  Package (= libignition-plugin-dev) \
-), $Version (% 1.2.1+osrf-1*) |\
+), $Version (% 1.3.0-1*) |\
 (Package (= ignition-rendering6) |\
  Package (= libignition-rendering6) |\
  Package (= libignition-rendering6-core-dev) |\
@@ -82,7 +82,7 @@ filter_formula: "\
  Package (= libignition-rendering6-ogre1-dev) |\
  Package (= libignition-rendering6-ogre2) |\
  Package (= libignition-rendering6-ogre2-dev) \
-), $Version (% 6.5.0-1*) |\
+), $Version (% 6.5.1-1*) |\
 (Package (= ignition-sensors6) |\
  Package (= libignition-sensors6) |\
  Package (= libignition-sensors6-air-pressure) |\
@@ -120,7 +120,7 @@ filter_formula: "\
 ), $Version (% 6.6.0-2*) |\
 (Package (= ignition-tools) |\
  Package (= libignition-tools-dev) \
-), $Version (% 1.4.1+osrf-1*) |\
+), $Version (% 1.5.1-1*) |\
 (Package (= ignition-transport11) |\
  Package (= ignition-transport11-cli) |\
  Package (= libignition-transport11) |\

--- a/config/ignition_fortress_ubuntu_jammy.yaml
+++ b/config/ignition_fortress_ubuntu_jammy.yaml
@@ -89,6 +89,8 @@ filter_formula: "\
  Package (= libignition-sensors6-air-pressure-dev) |\
  Package (= libignition-sensors6-altimeter) |\
  Package (= libignition-sensors6-altimeter-dev) |\
+ Package (= libignition-sensors6-boundingbox-camera) |\
+ Package (= libignition-sensors6-boundingbox-camera-dev) |\
  Package (= libignition-sensors6-camera) |\
  Package (= libignition-sensors6-camera-dev) |\
  Package (= libignition-sensors6-core-dev) |\

--- a/config/ignition_fortress_ubuntu_jammy.yaml
+++ b/config/ignition_fortress_ubuntu_jammy.yaml
@@ -8,7 +8,7 @@ filter_formula: "\
 ), $Version (% 1.0.3-1*) |\
 (Package (= ignition-cmake2) |\
  Package (= libignition-cmake2-dev) \
-), $Version (% 2.12.1-2*) |\
+), $Version (% 2.14.0-2*) |\
 (Package (= ignition-common4) |\
  Package (= libignition-common4) |\
  Package (= libignition-common4-av) |\
@@ -32,7 +32,7 @@ filter_formula: "\
  Package (= libignition-gazebo6-dev) |\
  Package (= libignition-gazebo6-plugins) |\
  Package (= python3-ignition-gazebo6) \
-), $Version (% 6.9.0-1*) |\
+), $Version (% 6.10.0-1*) |\
 (Package (= ignition-gui6) |\
  Package (= libignition-gui6) |\
  Package (= libignition-gui6-dev) \
@@ -82,7 +82,7 @@ filter_formula: "\
  Package (= libignition-rendering6-ogre1-dev) |\
  Package (= libignition-rendering6-ogre2) |\
  Package (= libignition-rendering6-ogre2-dev) \
-), $Version (% 6.4.0-1*) |\
+), $Version (% 6.5.0-1*) |\
 (Package (= ignition-sensors6) |\
  Package (= libignition-sensors6) |\
  Package (= libignition-sensors6-air-pressure) |\

--- a/config/ignition_fortress_ubuntu_jammy.yaml
+++ b/config/ignition_fortress_ubuntu_jammy.yaml
@@ -50,7 +50,7 @@ filter_formula: "\
  Package (= libignition-gazebo6-dbg) |\
  Package (= libignition-gazebo6-dev) |\
  Package (= libignition-gazebo6-plugins) |\
- Package (= python3-gz-sim6) \
+ Package (= python3-gz-sim6) |\
  Package (= python3-ignition-gazebo6) \
 ), $Version (% 6.11.0-2*) |\
 (Package (= ignition-gui6) |\
@@ -78,7 +78,7 @@ filter_formula: "\
  Package (= python3-ignition-math6) |\
  Package (= ruby-gz-math6) |\
  Package (= ruby-ignition-math6) \
-), $Version (% 6.12.0-2*) |\
+), $Version (% 6.12.0-3*) |\
 (Package (= ignition-msgs8) |\
  Package (= libgz-msgs8) |\
  Package (= libgz-msgs8-dev) |\

--- a/config/ignition_fortress_ubuntu_jammy.yaml
+++ b/config/ignition_fortress_ubuntu_jammy.yaml
@@ -241,7 +241,7 @@ filter_formula: "\
  Package (= libignition-utils1-cli-dev) |\
  Package (= libignition-utils1-dbg) |\
  Package (= libignition-utils1-dev) \
-), $Version (% 1.4.0-2*) |\
+), $Version (% 1.4.0-4*) |\
 (Package (= sdformat12) |\
  Package (= libsdformat12) |\
  Package (= libsdformat12-dbg) |\

--- a/config/ignition_fortress_ubuntu_jammy.yaml
+++ b/config/ignition_fortress_ubuntu_jammy.yaml
@@ -4,12 +4,25 @@ suites: [jammy]
 component: main
 architectures: [amd64, armhf, arm64, source]
 filter_formula: "\
-(Package (= ignition-fortress) \
-), $Version (% 1.0.3-1*) |\
+(Package (= gz-fortress) |\
+ Package (= ignition-fortress) \
+), $Version (% 1.0.3-2*) |\
 (Package (= ignition-cmake2) |\
+ Package (= libgz-cmake2-dev) |\
  Package (= libignition-cmake2-dev) \
 ), $Version (% 2.14.0-2*) |\
 (Package (= ignition-common4) |\
+ Package (= libgz-common4) |\
+ Package (= libgz-common4-av) |\
+ Package (= libgz-common4-av-dev) |\
+ Package (= libgz-common4-core-dev) |\
+ Package (= libgz-common4-dev) |\
+ Package (= libgz-common4-events) |\
+ Package (= libgz-common4-events-dev) |\
+ Package (= libgz-common4-graphics) |\
+ Package (= libgz-common4-graphics-dev) |\
+ Package (= libgz-common4-profiler) |\
+ Package (= libgz-common4-profiler-dev) |\
  Package (= libignition-common4) |\
  Package (= libignition-common4-av) |\
  Package (= libignition-common4-av-dev) |\
@@ -21,39 +34,72 @@ filter_formula: "\
  Package (= libignition-common4-graphics-dev) |\
  Package (= libignition-common4-profiler) |\
  Package (= libignition-common4-profiler-dev) \
-), $Version (% 4.5.1-2*) |\
+), $Version (% 4.5.2-1*) |\
 (Package (= ignition-fuel-tools7) |\
+ Package (= libgz-fuel-tools7) |\
+ Package (= libgz-fuel-tools7-dev) |\
  Package (= libignition-fuel-tools7) |\
  Package (= libignition-fuel-tools7-dev) \
-), $Version (% 7.0.0+osrf-1*) |\
+), $Version (% 7.1.0-1*) |\
 (Package (= ignition-gazebo6) |\
+ Package (= libgz-sim6) |\
+ Package (= libgz-sim6-dbg) |\
+ Package (= libgz-sim6-dev) |\
+ Package (= libgz-sim6-plugins) |\
  Package (= libignition-gazebo6) |\
  Package (= libignition-gazebo6-dbg) |\
  Package (= libignition-gazebo6-dev) |\
  Package (= libignition-gazebo6-plugins) |\
+ Package (= python3-gz-sim6) \
  Package (= python3-ignition-gazebo6) \
-), $Version (% 6.10.0-1*) |\
+), $Version (% 6.11.0-2*) |\
 (Package (= ignition-gui6) |\
+ Package (= libgz-gui6) |\
+ Package (= libgz-gui6-dev) |\
  Package (= libignition-gui6) |\
  Package (= libignition-gui6-dev) \
-), $Version (% 6.6.0-1*) |\
+), $Version (% 6.6.1-2*) |\
 (Package (= ignition-launch5) |\
+ Package (= libgz-launch5) |\
+ Package (= libgz-launch5-dev) |\
  Package (= libignition-launch5) |\
  Package (= libignition-launch5-dev) \
-), $Version (% 5.1.0-1*) |\
+), $Version (% 5.2.0-1*) |\
 (Package (= ignition-math6) |\
+ Package (= libgz-math6) |\
+ Package (= libgz-math6-dbg) |\
+ Package (= libgz-math6-dev) |\
+ Package (= libgz-math6-eigen3-dev) |\
  Package (= libignition-math6) |\
  Package (= libignition-math6-dbg) |\
  Package (= libignition-math6-dev) |\
  Package (= libignition-math6-eigen3-dev) |\
+ Package (= python3-gz-math6) |\
  Package (= python3-ignition-math6) |\
+ Package (= ruby-gz-math6) |\
  Package (= ruby-ignition-math6) \
 ), $Version (% 6.12.0-2*) |\
 (Package (= ignition-msgs8) |\
+ Package (= libgz-msgs8) |\
+ Package (= libgz-msgs8-dev) |\
  Package (= libignition-msgs8) |\
  Package (= libignition-msgs8-dev) \
-), $Version (% 8.6.0-1*) |\
+), $Version (% 8.6.0-3*) |\
 (Package (= ignition-physics5) |\
+ Package (= libgz-physics5) |\
+ Package (= libgz-physics5-bullet) |\
+ Package (= libgz-physics5-bullet-dev) |\
+ Package (= libgz-physics5-core-dev) |\
+ Package (= libgz-physics5-dartsim) |\
+ Package (= libgz-physics5-dartsim-dev) |\
+ Package (= libgz-physics5-dev) |\
+ Package (= libgz-physics5-heightmap-dev) |\
+ Package (= libgz-physics5-mesh-dev) |\
+ Package (= libgz-physics5-sdf-dev) |\
+ Package (= libgz-physics5-tpe) |\
+ Package (= libgz-physics5-tpe-dev) |\
+ Package (= libgz-physics5-tpelib) |\
+ Package (= libgz-physics5-tpelib-dev) |\
  Package (= libignition-physics5) |\
  Package (= libignition-physics5-bullet) |\
  Package (= libignition-physics5-bullet-dev) |\
@@ -68,13 +114,23 @@ filter_formula: "\
  Package (= libignition-physics5-tpe-dev) |\
  Package (= libignition-physics5-tpelib) |\
  Package (= libignition-physics5-tpelib-dev) \
-), $Version (% 5.2.0-1*) |\
+), $Version (% 5.2.0-2*) |\
 (Package (= ignition-plugin) |\
+ Package (= libgz-plugin) |\
+ Package (= libgz-plugin-dbg) |\
+ Package (= libgz-plugin-dev) |\
  Package (= libignition-plugin) |\
  Package (= libignition-plugin-dbg) |\
  Package (= libignition-plugin-dev) \
 ), $Version (% 1.3.0-1*) |\
 (Package (= ignition-rendering6) |\
+ Package (= libgz-rendering6) |\
+ Package (= libgz-rendering6-core-dev) |\
+ Package (= libgz-rendering6-dev) |\
+ Package (= libgz-rendering6-ogre1) |\
+ Package (= libgz-rendering6-ogre1-dev) |\
+ Package (= libgz-rendering6-ogre2) |\
+ Package (= libgz-rendering6-ogre2-dev) |\
  Package (= libignition-rendering6) |\
  Package (= libignition-rendering6-core-dev) |\
  Package (= libignition-rendering6-dev) |\
@@ -82,8 +138,43 @@ filter_formula: "\
  Package (= libignition-rendering6-ogre1-dev) |\
  Package (= libignition-rendering6-ogre2) |\
  Package (= libignition-rendering6-ogre2-dev) \
-), $Version (% 6.5.1-1*) |\
+), $Version (% 6.5.1-2*) |\
 (Package (= ignition-sensors6) |\
+ Package (= libgz-sensors6) |\
+ Package (= libgz-sensors6-air-pressure) |\
+ Package (= libgz-sensors6-air-pressure-dev) |\
+ Package (= libgz-sensors6-altimeter) |\
+ Package (= libgz-sensors6-altimeter-dev) |\
+ Package (= libgz-sensors6-boundingbox-camera) |\
+ Package (= libgz-sensors6-boundingbox-camera-dev) |\
+ Package (= libgz-sensors6-camera) |\
+ Package (= libgz-sensors6-camera-dev) |\
+ Package (= libgz-sensors6-core-dev) |\
+ Package (= libgz-sensors6-depth-camera) |\
+ Package (= libgz-sensors6-depth-camera-dev) |\
+ Package (= libgz-sensors6-dev) |\
+ Package (= libgz-sensors6-force-torque) |\
+ Package (= libgz-sensors6-force-torque-dev) |\
+ Package (= libgz-sensors6-gpu-lidar) |\
+ Package (= libgz-sensors6-gpu-lidar-dev) |\
+ Package (= libgz-sensors6-imu) |\
+ Package (= libgz-sensors6-imu-dev) |\
+ Package (= libgz-sensors6-lidar) |\
+ Package (= libgz-sensors6-lidar-dev) |\
+ Package (= libgz-sensors6-logical-camera) |\
+ Package (= libgz-sensors6-logical-camera-dev) |\
+ Package (= libgz-sensors6-magnetometer) |\
+ Package (= libgz-sensors6-magnetometer-dev) |\
+ Package (= libgz-sensors6-navsat) |\
+ Package (= libgz-sensors6-navsat-dev) |\
+ Package (= libgz-sensors6-rendering) |\
+ Package (= libgz-sensors6-rendering-dev) |\
+ Package (= libgz-sensors6-rgbd-camera) |\
+ Package (= libgz-sensors6-rgbd-camera-dev) |\
+ Package (= libgz-sensors6-segmentation-camera) |\
+ Package (= libgz-sensors6-segmentation-camera-dev) |\
+ Package (= libgz-sensors6-thermal-camera) |\
+ Package (= libgz-sensors6-thermal-camera-dev) |\
  Package (= libignition-sensors6) |\
  Package (= libignition-sensors6-air-pressure) |\
  Package (= libignition-sensors6-air-pressure-dev) |\
@@ -119,25 +210,38 @@ filter_formula: "\
  Package (= libignition-sensors6-segmentation-camera-dev) |\
  Package (= libignition-sensors6-thermal-camera) |\
  Package (= libignition-sensors6-thermal-camera-dev) \
-), $Version (% 6.6.0-2*) |\
-(Package (= ignition-tools) |\
+), $Version (% 6.6.0-3*) |\
+(Package (= gz-tools) |\
+ Package (= ignition-tools) |\
+ Package (= libgz-tools-dev) |\
  Package (= libignition-tools-dev) \
-), $Version (% 1.5.1-1*) |\
+), $Version (% 1.5.0-1*) |\
 (Package (= ignition-transport11) |\
+ Package (= gz-transport11-cli) |\
  Package (= ignition-transport11-cli) |\
+ Package (= libgz-transport11) |\
+ Package (= libgz-transport11-core-dev) |\
+ Package (= libgz-transport11-dbg) |\
+ Package (= libgz-transport11-dev) |\
+ Package (= libgz-transport11-log) |\
+ Package (= libgz-transport11-log-dev) |\
  Package (= libignition-transport11) |\
  Package (= libignition-transport11-core-dev) |\
  Package (= libignition-transport11-dbg) |\
  Package (= libignition-transport11-dev) |\
  Package (= libignition-transport11-log) |\
  Package (= libignition-transport11-log-dev) \
-), $Version (% 11.1.0-7*) |\
+), $Version (% 11.2.0-3*) |\
 (Package (= ignition-utils1) |\
+ Package (= libgz-utils1) |\
+ Package (= libgz-utils1-cli-dev) |\
+ Package (= libgz-utils1-dbg) |\
+ Package (= libgz-utils1-dev) |\
  Package (= libignition-utils1) |\
  Package (= libignition-utils1-cli-dev) |\
  Package (= libignition-utils1-dbg) |\
  Package (= libignition-utils1-dev) \
-), $Version (% 1.4.0-1*) |\
+), $Version (% 1.4.0-2*) |\
 (Package (= sdformat12) |\
  Package (= libsdformat12) |\
  Package (= libsdformat12-dbg) |\


### PR DESCRIPTION
* Builds on top of https://github.com/ros-infrastructure/reprepro-updater/pull/168
* Part of https://github.com/gazebo-tooling/release-tools/issues/788

Summary:

* Add all `gz` counterparts to `ignition` packages
* Bump to the latest releases. ⚠️ I've included some versions that are staged to be released, but not there yet:
    - [x] `gz-sim` 6.11.0-2
    - [x] `gz-utils` 1.4.0-2
* I didn't update Buster on purpose, because that's EOL and we haven't been making new releases for it

Here's the current status of Fortress source packages on packages.osrf (this doesn't check that the `gz` packages exist, I've done that manually 🙃 ):

![image](https://user-images.githubusercontent.com/5751272/185244080-a5ff5e87-0931-4997-8327-cf9c6b1532e1.png)
