### PR TITLE
Add colcon-clean package

### DIFF
--- a/config/colcon.debian.upstream.yaml
+++ b/config/colcon.debian.upstream.yaml
@@ -9,6 +9,7 @@ filter_formula: "\
 (Package (% python3-colcon-bash), $Version (% 0.4.2*))|\
 (Package (% python3-colcon-bazel), $Version (% 0.1.0*))|\
 (Package (% python3-colcon-cd), $Version (% 0.1.1*))|\
+(Package (% python3-colcon-clean), $Version (% 0.2.0*))|\
 (Package (% python3-colcon-cmake), $Version (% 0.2.27*))|\
 (Package (% python3-colcon-common-extensions), $Version (% 0.3.0*))|\
 (Package (% python3-colcon-core), $Version (% 0.11.0*))|\

--- a/config/colcon.ubuntu.upstream.yaml
+++ b/config/colcon.ubuntu.upstream.yaml
@@ -9,6 +9,7 @@ filter_formula: "\
 (Package (% python3-colcon-bash), $Version (% 0.4.2*))|\
 (Package (% python3-colcon-bazel), $Version (% 0.1.0*))|\
 (Package (% python3-colcon-cd), $Version (% 0.1.1*))|\
+(Package (% python3-colcon-clean), $Version (% 0.2.0*))|\
 (Package (% python3-colcon-cmake), $Version (% 0.2.27*))|\
 (Package (% python3-colcon-common-extensions), $Version (% 0.3.0*))|\
 (Package (% python3-colcon-core), $Version (% 0.11.0*))|\


### PR DESCRIPTION
Imported here: https://packagecloud.io/dirk-thomas/colcon

This package only targets Jammy and Bullseye due to dependency availability.