### PR TITLE
Update all Fortress versions to latest in Focal/Jammy

### DIFF
--- a/config/ignition_fortress_ubuntu_focal.yaml
+++ b/config/ignition_fortress_ubuntu_focal.yaml
@@ -34,13 +34,13 @@ filter_formula: "\
  Package (= libignition-common4-graphics-dev) |\
  Package (= libignition-common4-profiler) |\
  Package (= libignition-common4-profiler-dev) \
-), $Version (% 4.5.2-1*) |\
+), $Version (% 4.7.0-1*) |\
 (Package (= ignition-fuel-tools7) |\
  Package (= libgz-fuel-tools7) |\
  Package (= libgz-fuel-tools7-dev) |\
  Package (= libignition-fuel-tools7) |\
  Package (= libignition-fuel-tools7-dev) \
-), $Version (% 7.1.0-1*) |\
+), $Version (% 7.3.0-1*) |\
 (Package (= ignition-gazebo6) |\
  Package (= libgz-sim6) |\
  Package (= libgz-sim6-dbg) |\
@@ -52,19 +52,19 @@ filter_formula: "\
  Package (= libignition-gazebo6-plugins) |\
  Package (= python3-gz-sim6) |\
  Package (= python3-ignition-gazebo6) \
-), $Version (% 6.12.0-1*) |\
+), $Version (% 6.15.0-1*) |\
 (Package (= ignition-gui6) |\
  Package (= libgz-gui6) |\
  Package (= libgz-gui6-dev) |\
  Package (= libignition-gui6) |\
  Package (= libignition-gui6-dev) \
-), $Version (% 6.6.1-2*) |\
+), $Version (% 6.8.0-1*) |\
 (Package (= ignition-launch5) |\
  Package (= libgz-launch5) |\
  Package (= libgz-launch5-dev) |\
  Package (= libignition-launch5) |\
  Package (= libignition-launch5-dev) \
-), $Version (% 5.2.0-1*) |\
+), $Version (% 5.3.0-1*) |\
 (Package (= ignition-math6) |\
  Package (= libgz-math6) |\
  Package (= libgz-math6-dbg) |\
@@ -78,13 +78,13 @@ filter_formula: "\
  Package (= python3-ignition-math6) |\
  Package (= ruby-gz-math6) |\
  Package (= ruby-ignition-math6) \
-), $Version (% 6.13.0-1*) |\
+), $Version (% 6.15.0-1*) |\
 (Package (= ignition-msgs8) |\
  Package (= libgz-msgs8) |\
  Package (= libgz-msgs8-dev) |\
  Package (= libignition-msgs8) |\
  Package (= libignition-msgs8-dev) \
-), $Version (% 8.6.0-3*) |\
+), $Version (% 8.7.0-1*) |\
 (Package (= ignition-physics5) |\
  Package (= libgz-physics5) |\
  Package (= libgz-physics5-bullet) |\
@@ -114,7 +114,7 @@ filter_formula: "\
  Package (= libignition-physics5-tpe-dev) |\
  Package (= libignition-physics5-tpelib) |\
  Package (= libignition-physics5-tpelib-dev) \
-), $Version (% 5.2.0-2*) |\
+), $Version (% 5.3.2-1*) |\
 (Package (= ignition-plugin) |\
  Package (= libgz-plugin) |\
  Package (= libgz-plugin-dbg) |\
@@ -122,7 +122,7 @@ filter_formula: "\
  Package (= libignition-plugin) |\
  Package (= libignition-plugin-dbg) |\
  Package (= libignition-plugin-dev) \
-), $Version (% 1.3.0-1*) |\
+), $Version (% 1.4.0-1*) |\
 (Package (= ignition-rendering6) |\
  Package (= libgz-rendering6) |\
  Package (= libgz-rendering6-core-dev) |\
@@ -138,7 +138,7 @@ filter_formula: "\
  Package (= libignition-rendering6-ogre1-dev) |\
  Package (= libignition-rendering6-ogre2) |\
  Package (= libignition-rendering6-ogre2-dev) \
-), $Version (% 6.5.1-2*) |\
+), $Version (% 6.6.1-1*) |\
 (Package (= ignition-sensors6) |\
  Package (= libgz-sensors6) |\
  Package (= libgz-sensors6-air-pressure) |\
@@ -210,7 +210,7 @@ filter_formula: "\
  Package (= libignition-sensors6-segmentation-camera-dev) |\
  Package (= libignition-sensors6-thermal-camera) |\
  Package (= libignition-sensors6-thermal-camera-dev) \
-), $Version (% 6.6.0-3*) |\
+), $Version (% 6.7.1-1*) |\
 (Package (= gz-tools) |\
  Package (= ignition-tools) |\
  Package (= libgz-tools-dev) |\
@@ -231,7 +231,7 @@ filter_formula: "\
  Package (= libignition-transport11-dev) |\
  Package (= libignition-transport11-log) |\
  Package (= libignition-transport11-log-dev) \
-), $Version (% 11.2.0-3*) |\
+), $Version (% 11.4.1-1*) |\
 (Package (= ignition-utils1) |\
  Package (= libgz-utils1) |\
  Package (= libgz-utils1-cli-dev) |\
@@ -241,7 +241,7 @@ filter_formula: "\
  Package (= libignition-utils1-cli-dev) |\
  Package (= libignition-utils1-dbg) |\
  Package (= libignition-utils1-dev) \
-), $Version (% 1.4.0-4*) |\
+), $Version (% 1.5.1-1*) |\
 (Package (= ogre-2.2) |\
  Package (= blender-ogrexml-2.2) |\
  Package (= libogre-2.2) |\
@@ -255,5 +255,5 @@ filter_formula: "\
  Package (= libsdformat12-dev) |\
  Package (= sdformat12-doc) |\
  Package (= sdformat12-sdf) \
-), $Version (% 12.5.0-1*) \
+), $Version (% 12.7.2-1*) \
 "

--- a/config/ignition_fortress_ubuntu_jammy.yaml
+++ b/config/ignition_fortress_ubuntu_jammy.yaml
@@ -10,7 +10,7 @@ filter_formula: "\
 (Package (= ignition-cmake2) |\
  Package (= libgz-cmake2-dev) |\
  Package (= libignition-cmake2-dev) \
-), $Version (% 2.14.0-2*) |\
+), $Version (% 2.17.1-1*) |\
 (Package (= ignition-common4) |\
  Package (= libgz-common4) |\
  Package (= libgz-common4-av) |\
@@ -34,13 +34,13 @@ filter_formula: "\
  Package (= libignition-common4-graphics-dev) |\
  Package (= libignition-common4-profiler) |\
  Package (= libignition-common4-profiler-dev) \
-), $Version (% 4.5.2-1*) |\
+), $Version (% 4.7.0-1*) |\
 (Package (= ignition-fuel-tools7) |\
  Package (= libgz-fuel-tools7) |\
  Package (= libgz-fuel-tools7-dev) |\
  Package (= libignition-fuel-tools7) |\
  Package (= libignition-fuel-tools7-dev) \
-), $Version (% 7.1.0-1*) |\
+), $Version (% 7.3.0-1*) |\
 (Package (= ignition-gazebo6) |\
  Package (= libgz-sim6) |\
  Package (= libgz-sim6-dbg) |\
@@ -52,19 +52,19 @@ filter_formula: "\
  Package (= libignition-gazebo6-plugins) |\
  Package (= python3-gz-sim6) |\
  Package (= python3-ignition-gazebo6) \
-), $Version (% 6.11.0-2*) |\
+), $Version (% 6.15.0-1*) |\
 (Package (= ignition-gui6) |\
  Package (= libgz-gui6) |\
  Package (= libgz-gui6-dev) |\
  Package (= libignition-gui6) |\
  Package (= libignition-gui6-dev) \
-), $Version (% 6.6.1-2*) |\
+), $Version (% 6.8.0-1*) |\
 (Package (= ignition-launch5) |\
  Package (= libgz-launch5) |\
  Package (= libgz-launch5-dev) |\
  Package (= libignition-launch5) |\
  Package (= libignition-launch5-dev) \
-), $Version (% 5.2.0-1*) |\
+), $Version (% 5.3.0-1*) |\
 (Package (= ignition-math6) |\
  Package (= libgz-math6) |\
  Package (= libgz-math6-dbg) |\
@@ -78,13 +78,13 @@ filter_formula: "\
  Package (= python3-ignition-math6) |\
  Package (= ruby-gz-math6) |\
  Package (= ruby-ignition-math6) \
-), $Version (% 6.12.0-3*) |\
+), $Version (% 6.15.0-1*) |\
 (Package (= ignition-msgs8) |\
  Package (= libgz-msgs8) |\
  Package (= libgz-msgs8-dev) |\
  Package (= libignition-msgs8) |\
  Package (= libignition-msgs8-dev) \
-), $Version (% 8.6.0-3*) |\
+), $Version (% 8.7.0-1*) |\
 (Package (= ignition-physics5) |\
  Package (= libgz-physics5) |\
  Package (= libgz-physics5-bullet) |\
@@ -114,7 +114,7 @@ filter_formula: "\
  Package (= libignition-physics5-tpe-dev) |\
  Package (= libignition-physics5-tpelib) |\
  Package (= libignition-physics5-tpelib-dev) \
-), $Version (% 5.2.0-2*) |\
+), $Version (% 5.3.2-1*) |\
 (Package (= ignition-plugin) |\
  Package (= libgz-plugin) |\
  Package (= libgz-plugin-dbg) |\
@@ -122,7 +122,7 @@ filter_formula: "\
  Package (= libignition-plugin) |\
  Package (= libignition-plugin-dbg) |\
  Package (= libignition-plugin-dev) \
-), $Version (% 1.3.0-1*) |\
+), $Version (% 1.4.0-1*) |\
 (Package (= ignition-rendering6) |\
  Package (= libgz-rendering6) |\
  Package (= libgz-rendering6-core-dev) |\
@@ -138,7 +138,7 @@ filter_formula: "\
  Package (= libignition-rendering6-ogre1-dev) |\
  Package (= libignition-rendering6-ogre2) |\
  Package (= libignition-rendering6-ogre2-dev) \
-), $Version (% 6.5.1-2*) |\
+), $Version (% 6.6.1-1*) |\
 (Package (= ignition-sensors6) |\
  Package (= libgz-sensors6) |\
  Package (= libgz-sensors6-air-pressure) |\
@@ -210,7 +210,7 @@ filter_formula: "\
  Package (= libignition-sensors6-segmentation-camera-dev) |\
  Package (= libignition-sensors6-thermal-camera) |\
  Package (= libignition-sensors6-thermal-camera-dev) \
-), $Version (% 6.6.0-3*) |\
+), $Version (% 6.7.1-1*) |\
 (Package (= gz-tools) |\
  Package (= ignition-tools) |\
  Package (= libgz-tools-dev) |\
@@ -231,7 +231,7 @@ filter_formula: "\
  Package (= libignition-transport11-dev) |\
  Package (= libignition-transport11-log) |\
  Package (= libignition-transport11-log-dev) \
-), $Version (% 11.2.0-3*) |\
+), $Version (% 11.4.1-1*) |\
 (Package (= ignition-utils1) |\
  Package (= libgz-utils1) |\
  Package (= libgz-utils1-cli-dev) |\
@@ -241,12 +241,12 @@ filter_formula: "\
  Package (= libignition-utils1-cli-dev) |\
  Package (= libignition-utils1-dbg) |\
  Package (= libignition-utils1-dev) \
-), $Version (% 1.4.0-4*) |\
+), $Version (% 1.5.1-1*) |\
 (Package (= sdformat12) |\
  Package (= libsdformat12) |\
  Package (= libsdformat12-dbg) |\
  Package (= libsdformat12-dev) |\
  Package (= sdformat12-doc) |\
  Package (= sdformat12-sdf) \
-), $Version (% 12.5.0-1*) \
+), $Version (% 12.7.2-1*) \
 "


### PR DESCRIPTION
Prepare the sync of all Gazebo Fortress latest versions in packages.o.o corresponding to Ubuntu Jammy and Ubuntu Focal. 