### PR TITLE
Rework some sharp edges in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,21 +9,8 @@ on:
 
 
 jobs:
-  bionic-ci:
+  focal-ci:
     runs-on: ubuntu-20.04
-    name: Focal Aptly ${{ matrix.job_type }} -
-          debug ${{ matrix.show_debug_cmds }}
-    strategy:
-      matrix:
-        show_debug_cmds:
-          - true
-          - false
-        job_type:
-          - 'CI'
-          - 'CONFIG_TESTER'
-        exclude:
-          - job_type: 'CONFIG_TESTER'
-            show_debug_cmds: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -69,21 +56,31 @@ jobs:
 
       # CI TESTING
       - name: Run CI tests
-        if: ${{ matrix.job_type == 'CI' }}
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
             python3 scripts/aptly/aptly_importer_TEST.py
         env:
-          _DEBUG_MSGS_REPREPRO_UPDATER_TEST_SUITE_: ${{ matrix.show_debug_cmds }}
+          _DEBUG_MSGS_REPREPRO_UPDATER_TEST_SUITE_: false
           _ALLOW_DESTRUCTIVE_TESTS_REPREPRO_UPDATER_TEST_SUITE_: true
+
+      # CI TESTING (debug)
+      - name: Run CI tests (debug)
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+            python3 scripts/aptly/aptly_importer_TEST.py
+        env:
+          _DEBUG_MSGS_REPREPRO_UPDATER_TEST_SUITE_: true
+          _ALLOW_DESTRUCTIVE_TESTS_REPREPRO_UPDATER_TEST_SUITE_: true
+
       # CONFIG FILE TESTER
       - name: Idenfify files changed in this PR.
         id: files
-        if: ${{ matrix.job_type == 'CONFIG_TESTER' }}
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
-          git diff --name-only origin/${{ github.base_ref }}...origin/${{ github.head_ref }}
-          echo "::set-output name=changed-files::$(git diff --name-only origin/${{ github.base_ref }}...origin/${{ github.head_ref }}| tr '\n' ' ')"
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }}... | tr '\n' ' ')
+          echo "changed-files=$CHANGED_FILES" | tee $GITHUB_OUTPUT
       - name: Run testing on changed config files
-        if: ${{ matrix.job_type == 'CONFIG_TESTER' }}
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           for changed_file in ${{ steps.files.outputs.changed-files }}; do
             if [[ ${changed_file} != ${changed_file/config\/*.yaml} ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
             gpg --gen-key --batch genkey
 
       # CI TESTING
-      - name: Run CI tests
+      - name: Run software testsuite
         if: ${{ github.event_name != 'pull_request' }}
         run: |
             python3 scripts/aptly/aptly_importer_TEST.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 
 jobs:
-  focal-ci:
+  ci:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout


### PR DESCRIPTION
Two high-level changes here:
* Drop the matrix in favor of conditionally running steps
   The job runs so fast that I don't think there's any advantage in parallelizing using the matrix
* Use base ref SHA for determining which files changed
   The intent here is to make PRs from forks work by not referencing `origin`.