### PR TITLE
Sync Fortress gz-sim 6.16.0-2 for Jammy and Focal

### DIFF
--- a/config/ignition_fortress_ubuntu_focal.yaml
+++ b/config/ignition_fortress_ubuntu_focal.yaml
@@ -52,7 +52,7 @@ filter_formula: "\
  Package (= libignition-gazebo6-plugins) |\
  Package (= python3-gz-sim6) |\
  Package (= python3-ignition-gazebo6) \
-), $Version (% 6.16.0-1*) |\
+), $Version (% 6.16.0-2*) |\
 (Package (= ignition-gui6) |\
  Package (= libgz-gui6) |\
  Package (= libgz-gui6-dev) |\

--- a/config/ignition_fortress_ubuntu_jammy.yaml
+++ b/config/ignition_fortress_ubuntu_jammy.yaml
@@ -52,7 +52,7 @@ filter_formula: "\
  Package (= libignition-gazebo6-plugins) |\
  Package (= python3-gz-sim6) |\
  Package (= python3-ignition-gazebo6) \
-), $Version (% 6.16.0-1*) |\
+), $Version (% 6.16.0-2*) |\
 (Package (= ignition-gui6) |\
  Package (= libgz-gui6) |\
  Package (= libgz-gui6-dev) |\


### PR DESCRIPTION
Sync a [release version bump](https://github.com/gazebo-release/gz-sim6-release/pull/26) in gz-sim for fixing the bug in https://github.com/gazebosim/gz-sim/issues/2301#issuecomment-1919369942. 
