### PR TITLE
Fix reprepro filter in Citadel Gazebo11 file

### DIFF
--- a/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
+++ b/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
@@ -4,22 +4,22 @@ suites: [focal]
 component: main
 architectures: [amd64, armhf, arm64, source]
 filter_formula: "\
-(Package (= gazebo11) |\
+((Package (= gazebo11) |\
  Package (= gazebo11-common) |\
  Package (= gazebo11-dbg) |\
  Package (= gazebo11-doc) |\
  Package (= gazebo11-plugin-base) |\
  Package (= libgazebo11) |\
  Package (= libgazebo11-dev) \
-), $Version (% 11.15.1-1*) |\
-(Package (= gz-citadel) |\
+), $Version (% 11.15.1-1*)) |\
+((Package (= gz-citadel) |\
  Package (= ignition-citadel) \
-), $Version (% 1.0.2-2*) |\
-(Package (= ignition-cmake2) |\
+), $Version (% 1.0.2-2*)) |\
+((Package (= ignition-cmake2) |\
  Package (= libgz-cmake2-dev) |\
  Package (= libignition-cmake2-dev) \
-), $Version (% 2.17.2-1*) |\
-(Package (= ignition-common3) |\
+), $Version (% 2.17.2-1*)) |\
+((Package (= ignition-common3) |\
  Package (= libgz-common3) |\
  Package (= libgz-common3-av) |\
  Package (= libgz-common3-av-dev) |\
@@ -42,14 +42,14 @@ filter_formula: "\
  Package (= libignition-common3-graphics-dev) |\
  Package (= libignition-common3-profiler) |\
  Package (= libignition-common3-profiler-dev) \
-), $Version (% 3.17.0-1*) |\
-(Package (= ignition-fuel-tools4) |\
+), $Version (% 3.17.0-1*)) |\
+((Package (= ignition-fuel-tools4) |\
  Package (= libgz-fuel-tools4) |\
  Package (= libgz-fuel-tools4-dev) |\
  Package (= libignition-fuel-tools4) |\
  Package (= libignition-fuel-tools4-dev) \
-), $Version (% 4.9.1-1*) |\
-(Package (= ignition-gazebo3) |\
+), $Version (% 4.9.1-1*)) |\
+((Package (= ignition-gazebo3) |\
  Package (= libgz-sim3) |\
  Package (= libgz-sim3-dbg) |\
  Package (= libgz-sim3-dev) |\
@@ -58,20 +58,20 @@ filter_formula: "\
  Package (= libignition-gazebo3-dbg) |\
  Package (= libignition-gazebo3-dev) |\
  Package (= libignition-gazebo3-plugins) \
-), $Version (% 3.15.1-1*) |\
-(Package (= ignition-gui3) |\
+), $Version (% 3.15.1-1*)) |\
+((Package (= ignition-gui3) |\
  Package (= libgz-gui3) |\
  Package (= libgz-gui3-dev) |\
  Package (= libignition-gui3) |\
  Package (= libignition-gui3-dev) \
-), $Version (% 3.12.0-1*) |\
-(Package (= ignition-launch2) |\
+), $Version (% 3.12.0-1*)) |\
+((Package (= ignition-launch2) |\
  Package (= libgz-launch2) |\
  Package (= libgz-launch2-dev) |\
  Package (= libignition-launch2) |\
  Package (= libignition-launch2-dev) \
-), $Version (% 2.3.1-1*) |\
-(Package (= ignition-math6) |\
+), $Version (% 2.3.1-1*)) |\
+((Package (= ignition-math6) |\
  Package (= libgz-math6) |\
  Package (= libgz-math6-dbg) |\
  Package (= libgz-math6-dev) |\
@@ -84,14 +84,14 @@ filter_formula: "\
  Package (= python3-ignition-math6) |\
  Package (= ruby-gz-math6) |\
  Package (= ruby-ignition-math6) \
-), $Version (% 6.15.1-1*) |\
-(Package (= ignition-msgs5) |\
+), $Version (% 6.15.1-1*)) |\
+((Package (= ignition-msgs5) |\
  Package (= libgz-msgs5) |\
  Package (= libgz-msgs5-dev) |\
  Package (= libignition-msgs5) |\
  Package (= libignition-msgs5-dev) \
-), $Version (% 5.11.0-4*) |\
-(Package (= ignition-physics2) |\
+), $Version (% 5.11.0-4*)) |\
+((Package (= ignition-physics2) |\
  Package (= libgz-physics2) |\
  Package (= libgz-physics2-core-dev) |\
  Package (= libgz-physics2-dartsim) |\
@@ -114,16 +114,16 @@ filter_formula: "\
  Package (= libignition-physics2-tpe-dev) |\
  Package (= libignition-physics2-tpelib) |\
  Package (= libignition-physics2-tpelib-dev) \
-), $Version (% 2.6.2-1*) |\
-(Package (= ignition-plugin) |\
+), $Version (% 2.6.2-1*)) |\
+((Package (= ignition-plugin) |\
  Package (= libgz-plugin) |\
  Package (= libgz-plugin-dbg) |\
  Package (= libgz-plugin-dev) |\
  Package (= libignition-plugin) |\
  Package (= libignition-plugin-dbg) |\
  Package (= libignition-plugin-dev) \
-), $Version (% 1.4.0-1*) |\
-(Package (= ignition-rendering3) |\
+), $Version (% 1.4.0-1*)) |\
+((Package (= ignition-rendering3) |\
  Package (= libgz-rendering3) |\
  Package (= libgz-rendering3-core-dev) |\
  Package (= libgz-rendering3-dev) |\
@@ -138,8 +138,8 @@ filter_formula: "\
  Package (= libignition-rendering3-ogre1-dev) |\
  Package (= libignition-rendering3-ogre2) |\
  Package (= libignition-rendering3-ogre2-dev) \
-), $Version (% 3.7.2-5*) |\
-(Package (= ignition-sensors3) |\
+), $Version (% 3.7.2-5*)) |\
+((Package (= ignition-sensors3) |\
  Package (= libgz-sensors3) |\
  Package (= libgz-sensors3-air-pressure) |\
  Package (= libgz-sensors3-air-pressure-dev) |\
@@ -194,13 +194,13 @@ filter_formula: "\
  Package (= libignition-sensors3-rgbd-camera-dev) |\
  Package (= libignition-sensors3-thermal-camera) |\
  Package (= libignition-sensors3-thermal-camera-dev) \
-), $Version (% 3.6.0-1*) |\
-(Package (= gz-tools) |\
+), $Version (% 3.6.0-1*)) |\
+((Package (= gz-tools) |\
  Package (= ignition-tools) |\
  Package (= libgz-tools-dev) |\
  Package (= libignition-tools-dev) \
-), $Version (% 1.5.0-1*) |\
-(Package (= ignition-transport8) |\
+), $Version (% 1.5.0-1*)) |\
+((Package (= ignition-transport8) |\
  Package (= libgz-transport8) |\
  Package (= libgz-transport8-core-dev) |\
  Package (= libgz-transport8-dbg) |\
@@ -213,19 +213,19 @@ filter_formula: "\
  Package (= libignition-transport8-dev) |\
  Package (= libignition-transport8-log) |\
  Package (= libignition-transport8-log-dev) \
-), $Version (% 8.5.0-2*) |\
-(Package (= ogre-2.1) |\
+), $Version (% 8.5.0-2*)) |\
+((Package (= ogre-2.1) |\
  Package (= blender-ogrexml-2.1) |\
  Package (= libogre-2.1) |\
  Package (= libogre-2.1-dev) |\
  Package (= ogre-2.1-doc) |\
  Package (= ogre-2.1-tools) \
-), $Version (% 2.0.9999~20180616~06a386f-3*) |\
-(Package (= sdformat9) |\
+), $Version (% 2.0.9999~20180616~06a386f-3*)) |\
+((Package (= sdformat9) |\
  Package (= libsdformat9) |\
  Package (= libsdformat9-dbg) |\
  Package (= libsdformat9-dev) |\
  Package (= sdformat9-doc) |\
  Package (= sdformat9-sdf) \
-), $Version (% 9.10.1-1*) \
+), $Version (% 9.10.1-1*)) \
 "


### PR DESCRIPTION
reprepro does not handle correctly our conditional groups  formed by `( (Package | Package | Package) AND Version )`. I modified them to add an extra parenthesis around the whole group and the things seems to work now:

https://build.ros.org/job/import_upstream/332/consoleFull

The sed command is: `sed -i -e 's/(Package/\((Package/' -e 's/Version \(.*\))/Version \1))/'`