### PR TITLE
Add packages.o.o verify key to ignition_citadel_gazebo11_ubuntu_focal

### DIFF
--- a/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
+++ b/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
@@ -3,6 +3,7 @@ method: http://packages.osrfoundation.org/gazebo/ubuntu-stable
 suites: [focal]
 component: main
 architectures: [amd64, armhf, arm64, source]
+verify_release: 67170598AF249743
 filter_formula: "\
 (Package (= gazebo11) |\
  Package (= gazebo11-common) |\


### PR DESCRIPTION
How did I get the value for the verify_release that is a bit special:

```
wget https://packages.osrfoundation.org/gazebo/ubuntu-stable/dists/focal/Release.gpg
# the keyid in this gpg command
gpg --list-packets Release.gpg 
# off=0 ctb=89 tag=2 hlen=3 plen=307
:signature packet: algo 1, keyid 67170598AF249743
	version 4, created 1733241503, md5len 0, sigclass 0x00
	digest algo 10, begin of digest a8 86
	hashed subpkt 33 len 21 (issuer fpr v4 D2486D2DD83DB69272AFE98867170598AF249743)
	hashed subpkt 2 len 4 (sig created 2024-12-03)
	subpkt 16 len 8 (issuer key
```

Seem to match the last 16 chars of the long key id:
```
❯ gpg --list-keys | grep -2 67170598AF249743

pub   rsa2048 2015-04-01 [SC]
      D2486D2DD83DB69272AFE98867170598AF249743
uid           [ unknown] OSRF Repository (OSRF Repository GPG key) <osrfbuild@osrfoundation.org>
sub   rsa2048 2015-04-01 [E]
```

It is being used here https://build.ros.org/job/import_upstream/333/consoleFull