### PR TITLE
Fix Citadel upload for msgs5 and transport8

### DIFF
--- a/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
+++ b/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
@@ -91,7 +91,7 @@ filter_formula: "\
  Package (= libgz-msgs5-dev) |\
  Package (= libignition-msgs5) |\
  Package (= libignition-msgs5-dev) \
-), $Version (% 5.11.0-4*)) |\
+), $Version (% 5.11.0-1*)) |\
 ((Package (= ignition-physics2) |\
  Package (= libgz-physics2) |\
  Package (= libgz-physics2-core-dev) |\
@@ -214,7 +214,7 @@ filter_formula: "\
  Package (= libignition-transport8-dev) |\
  Package (= libignition-transport8-log) |\
  Package (= libignition-transport8-log-dev) \
-), $Version (% 8.5.0-2*)) |\
+), $Version (% 8.5.0-1*)) |\
 ((Package (= ogre-2.1) |\
  Package (= blender-ogrexml-2.1) |\
  Package (= libogre-2.1) |\


### PR DESCRIPTION
Related to https://github.com/gazebosim/gazebo-classic/issues/3416

Some release versions do not match the Packages file in the focal directory, particularly msgs5 and transport8. Used this changed locally to run an import upstream dry-run and the log displays the output of both packages: https://build.ros.org/job/import_upstream/335/consoleFull.

