### PR TITLE
Sync libraries used by Gazebo11 (Gazebo classic)

### DIFF
--- a/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
+++ b/config/ignition_citadel_gazebo11_ubuntu_focal.yaml
@@ -43,13 +43,13 @@ filter_formula: "\
  Package (= libignition-common3-graphics-dev) |\
  Package (= libignition-common3-profiler) |\
  Package (= libignition-common3-profiler-dev) \
-), $Version (% 3.17.0-1*)) |\
+), $Version (% 3.17.1-1*)) |\
 ((Package (= ignition-fuel-tools4) |\
  Package (= libgz-fuel-tools4) |\
  Package (= libgz-fuel-tools4-dev) |\
  Package (= libignition-fuel-tools4) |\
  Package (= libignition-fuel-tools4-dev) \
-), $Version (% 4.9.1-1*)) |\
+), $Version (% 4.9.2-1*)) |\
 ((Package (= ignition-gazebo3) |\
  Package (= libgz-sim3) |\
  Package (= libgz-sim3-dbg) |\
@@ -91,7 +91,7 @@ filter_formula: "\
  Package (= libgz-msgs5-dev) |\
  Package (= libignition-msgs5) |\
  Package (= libignition-msgs5-dev) \
-), $Version (% 5.11.0-1*)) |\
+), $Version (% 5.11.1-1*)) |\
 ((Package (= ignition-physics2) |\
  Package (= libgz-physics2) |\
  Package (= libgz-physics2-core-dev) |\
@@ -214,7 +214,7 @@ filter_formula: "\
  Package (= libignition-transport8-dev) |\
  Package (= libignition-transport8-log) |\
  Package (= libignition-transport8-log-dev) \
-), $Version (% 8.5.0-1*)) |\
+), $Version (% 8.5.1-1*)) |\
 ((Package (= ogre-2.1) |\
  Package (= blender-ogrexml-2.1) |\
  Package (= libogre-2.1) |\


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1252

This is the last sync of these libraries as Gazebo Classic has reached end of life.

