### PR TITLE
24.04 migration

### DIFF
--- a/src/reprepro_updater/conf.py
+++ b/src/reprepro_updater/conf.py
@@ -30,7 +30,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 import os
 
 
@@ -239,7 +239,7 @@ class ConfGenerator(object):
 
 
 def load_conf(config_name=None):
-    config = SafeConfigParser()
+    config = ConfigParser()
     config_file = os.path.join(
         os.path.expanduser('~'), '.buildfarm', 'reprepro-updater.ini')
 

--- a/src/reprepro_updater/repository_info.py
+++ b/src/reprepro_updater/repository_info.py
@@ -26,7 +26,7 @@ class RepositoryInfo:
         with open(packages_filepath, 'r') as packages_file:
             packages_contents = packages_file.read()
         for section in packages_contents.split('\n\n'):
-            if section is '':
+            if section == '':
                 continue
             name = None
             depends = set()


### PR DESCRIPTION
Fixes:
* Deprecated SafeConfigParser usage. Replaced with ConfigParser
* SyntaxWarning of empty string comparison