### PR TITLE
Use yaml.safe_load instead of yaml.load

### DIFF
--- a/scripts/import_upstream.py
+++ b/scripts/import_upstream.py
@@ -46,7 +46,7 @@ target_distros = set()
 for fname in yaml_files:
     with open(fname) as fh:
         print("loading config file: %s" % fname)
-        yaml_dict = yaml.load(fh.read())
+        yaml_dict = yaml.safe_load(fh.read())
         if 'name' not in yaml_dict:
             print("error %s does not include a name element" % fname)
             continue


### PR DESCRIPTION
import_upstream job is failing in python 3.12 because yaml.load needs a Loader param:

```
00:00:04.898 loading config file: /home/jenkins-agent/reprepro_config/ros_bootstrap.yaml
00:00:05.000 Traceback (most recent call last):
00:00:05.000   File "/home/jenkins-agent/workspace/import_upstream/reprepro-updater/scripts/import_upstream.py", line 49, in <module>
00:00:05.000     yaml_dict = yaml.load(fh.read())
```