### PR TITLE
Add LockContext for interacting with the repos in two remaining places

### DIFF
--- a/remove_packages.py
+++ b/remove_packages.py
@@ -6,9 +6,12 @@
 from __future__ import print_function
 
 import argparse
+import os
 import subprocess
 import sys
 import time
+
+from reprepro_updater.helpers import LockContext
 
 DISTROS = ['precise',
            'quantal',
@@ -49,9 +52,14 @@ def apply_command_template(repo, command_arg, distro, regex, dry_run=False):
         command_template = 'echo ' + command_template
     _cmd = command_template.split() + [regex]
     print("Running %s" % _cmd)
-    subprocess.Popen(_cmd)
+
+    lockfile = os.path.join(repo, 'lock')
+    with LockContext(lockfile):
+        process = subprocess.Popen(_cmd)
+        process.wait()
+
     # sleep to let the lock file cleanup before iterating
-    print('Sleeping to allow lock reset')
+    print('Sleeping to allow internal reprepro lock to reset')
     time.sleep(2.0)
 
 

--- a/scripts/sync_ros_packages.py
+++ b/scripts/sync_ros_packages.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 
 import datetime
+import os
 from optparse import OptionParser
 import sys
 
@@ -9,6 +10,7 @@ from reprepro_updater import conf
 from reprepro_updater import diff_repos
 from reprepro_updater.helpers import run_cleanup
 from reprepro_updater.helpers import run_update
+from reprepro_updater.helpers import LockContext
 
 parser = OptionParser()
 parser.add_option("-r", "--rosdistro", dest="rosdistro")
@@ -108,16 +110,18 @@ for ubuntu_distro in distros:
             ubuntu_distro,
             'main',
             package_architecture)
-        try:
-            pf_old = diff_repos.get_packagefile_from_url(target_url)
-        except RuntimeError as ex:
-            print("Exception: %s \n NOT Computing diff" % ex, file=sys.stderr)
-            continue
-        try:
-            pf_new = diff_repos.get_packagefile_from_url(upstream_url)
-        except RuntimeError as ex:
-            print("Exception: %s \n NOT Computing diff" % ex, file=sys.stderr)
-            continue
+        lockfile = os.path.join(conf_params.repository_path, 'lock')
+        with LockContext(lockfile):
+            try:
+                pf_old = diff_repos.get_packagefile_from_url(target_url)
+            except RuntimeError as ex:
+                print("Exception: %s \n NOT Computing diff" % ex, file=sys.stderr)
+                continue
+            try:
+                pf_new = diff_repos.get_packagefile_from_url(upstream_url)
+            except RuntimeError as ex:
+                print("Exception: %s \n NOT Computing diff" % ex, file=sys.stderr)
+                continue
         dtime = datetime.datetime.now()
         dtime = dtime.replace(microsecond=0)
         print("Difference between '%s' and '%s' computed at %s" %


### PR DESCRIPTION
There are a few other places where there is read only access when computing diffs that will only end up with the read operations that sequentially might be inconsistent but they'll clean up on the next cycle. 

