### PR TITLE
Add dart 6.16.6+ds-3~osrf1~resolute

### DIFF
--- a/config/packages.osrfoundation.org/dart6.13_gazebo_resolute.ppa.yaml
+++ b/config/packages.osrfoundation.org/dart6.13_gazebo_resolute.ppa.yaml
@@ -1,0 +1,9 @@
+# To be merged with dart6.13_gazebo.pp.yaml once
+# https://github.com/gazebosim/gz-physics/issues/586 is resolved
+name: dart6.13_gazebo_resolute_ppa
+method: http://ppa.launchpad.net/openrobotics/dart6.13-gazebo/ubuntu/
+suites: [resolute]
+component: main
+architectures: [amd64, arm64, source]
+filter_formula: Package (% *dart*6.16*), $SourceVersion(== 6.16.6+ds-3~osrf1~resolute)
+verify_release: blindtrust


### PR DESCRIPTION
Imports the dart 6.16 packages built in ppa:openrobotics/dart6.13-gazebo for Ubuntu 26.04 (resolute) into the osrfoundation apt repository.

Part of #https://github.com/gazebo-tooling/release-tools/issues/1485

Tested in: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=reprepro_importer&build=184)](https://build.osrfoundation.org/job/reprepro_importer/184/) for the nightly repository
