### PR TITLE
Sync latest Fortress packages for Jammy

### DIFF
--- a/config/ignition_fortress_ubuntu_jammy.yaml
+++ b/config/ignition_fortress_ubuntu_jammy.yaml
@@ -10,7 +10,7 @@ filter_formula: "\
 (Package (= ignition-cmake2) |\
  Package (= libgz-cmake2-dev) |\
  Package (= libignition-cmake2-dev) \
-), $Version (% 2.17.1-1*) |\
+), $Version (% 2.18.0-1*) |\
 (Package (= ignition-common4) |\
  Package (= libgz-common4) |\
  Package (= libgz-common4-av) |\
@@ -34,13 +34,13 @@ filter_formula: "\
  Package (= libignition-common4-graphics-dev) |\
  Package (= libignition-common4-profiler) |\
  Package (= libignition-common4-profiler-dev) \
-), $Version (% 4.7.0-1*) |\
+), $Version (% 4.8.1-1*) |\
 (Package (= ignition-fuel-tools7) |\
  Package (= libgz-fuel-tools7) |\
  Package (= libgz-fuel-tools7-dev) |\
  Package (= libignition-fuel-tools7) |\
  Package (= libignition-fuel-tools7-dev) \
-), $Version (% 7.3.0-1*) |\
+), $Version (% 7.3.1-1*) |\
 (Package (= ignition-gazebo6) |\
  Package (= libgz-sim6) |\
  Package (= libgz-sim6-dbg) |\
@@ -52,19 +52,19 @@ filter_formula: "\
  Package (= libignition-gazebo6-plugins) |\
  Package (= python3-gz-sim6) |\
  Package (= python3-ignition-gazebo6) \
-), $Version (% 6.16.0-2*) |\
+), $Version (% 6.18.0-1*) |\
 (Package (= ignition-gui6) |\
  Package (= libgz-gui6) |\
  Package (= libgz-gui6-dev) |\
  Package (= libignition-gui6) |\
  Package (= libignition-gui6-dev) \
-), $Version (% 6.8.0-1*) |\
+), $Version (% 6.9.0-1*) |\
 (Package (= ignition-launch5) |\
  Package (= libgz-launch5) |\
  Package (= libgz-launch5-dev) |\
  Package (= libignition-launch5) |\
  Package (= libignition-launch5-dev) \
-), $Version (% 5.3.0-1*) |\
+), $Version (% 5.3.1-1*) |\
 (Package (= ignition-math6) |\
  Package (= libgz-math6) |\
  Package (= libgz-math6-dbg) |\
@@ -78,7 +78,7 @@ filter_formula: "\
  Package (= python3-ignition-math6) |\
  Package (= ruby-gz-math6) |\
  Package (= ruby-ignition-math6) \
-), $Version (% 6.15.1-1*) |\
+), $Version (% 6.16.0-1*) |\
 (Package (= ignition-msgs8) |\
  Package (= libgz-msgs8) |\
  Package (= libgz-msgs8-dev) |\
@@ -114,7 +114,7 @@ filter_formula: "\
  Package (= libignition-physics5-tpe-dev) |\
  Package (= libignition-physics5-tpelib) |\
  Package (= libignition-physics5-tpelib-dev) \
-), $Version (% 5.3.2-1*) |\
+), $Version (% 5.4.0-1*) |\
 (Package (= ignition-plugin) |\
  Package (= libgz-plugin) |\
  Package (= libgz-plugin-dbg) |\
@@ -138,7 +138,7 @@ filter_formula: "\
  Package (= libignition-rendering6-ogre1-dev) |\
  Package (= libignition-rendering6-ogre2) |\
  Package (= libignition-rendering6-ogre2-dev) \
-), $Version (% 6.6.3-1*) |\
+), $Version (% 6.6.4-1*) |\
 (Package (= ignition-sensors6) |\
  Package (= libgz-sensors6) |\
  Package (= libgz-sensors6-air-pressure) |\
@@ -210,7 +210,7 @@ filter_formula: "\
  Package (= libignition-sensors6-segmentation-camera-dev) |\
  Package (= libignition-sensors6-thermal-camera) |\
  Package (= libignition-sensors6-thermal-camera-dev) \
-), $Version (% 6.8.0-1*) |\
+), $Version (% 6.9.0-1*) |\
 (Package (= gz-tools) |\
  Package (= ignition-tools) |\
  Package (= libgz-tools-dev) |\
@@ -235,7 +235,7 @@ filter_formula: "\
  Package (= libignition-transport11-log-dev) |\
  Package (= libignition-transport11-parameters) |\
  Package (= libignition-transport11-parameters-dev) \
-), $Version (% 11.4.1-1*) |\
+), $Version (% 11.4.2-1*) |\
 (Package (= ignition-utils1) |\
  Package (= libgz-utils1) |\
  Package (= libgz-utils1-cli-dev) |\
@@ -252,5 +252,5 @@ filter_formula: "\
  Package (= libsdformat12-dev) |\
  Package (= sdformat12-doc) |\
  Package (= sdformat12-sdf) \
-), $Version (% 12.7.2-1*) \
+), $Version (% 12.9.0-1*) \
 "


### PR DESCRIPTION
To verify, I've used this python script: https://gist.github.com/azeey/379be3f8b8ff1b65117848bc767bb5b5, which parses the `Packages` file from packages.osrfoundation.org

```
Fetching packages list from http://packages.osrfoundation.org/gazebo/ubuntu-stable/dists/jammy/main/binary-amd64/Packages.gz...
Decompressing packages list...
Parsing packages...

Latest versions available on packages.osrfoundation.org (Jammy amd64):
---------------------------------------------------------------------------
Package Name                             | Latest Version in Repo
---------------------------------------------------------------------------
libignition-cmake2-dev                   | 2.18.0-1~jammy
libignition-common4                      | 4.8.1-1~jammy
libignition-fuel-tools7                  | 7.3.1-1~jammy
libignition-gazebo6                      | 6.18.0-1~jammy
libignition-gui6                         | 6.9.0-1~jammy
libignition-launch5                      | 5.3.1-1~jammy
libignition-math6                        | 6.16.0-1~jammy
libignition-msgs8                        | 8.7.0-1~jammy
libignition-physics5                     | 5.4.0-1~jammy
libignition-plugin                       | 1.4.0-1~jammy
libignition-rendering6                   | 6.6.4-1~jammy
libignition-sensors6                     | 6.9.0-1~jammy
libignition-tools-dev                    | 1.5.0-1~jammy
libignition-transport11                  | 11.4.2-1~jammy
libignition-utils1                       | 1.5.1-1~jammy
libsdformat12                            | 12.9.0-1~jammy

```
Generated-by: Gemini 3.0 Pro