### PR TITLE
Import upstream colcon packages for Resolute

### DIFF
--- a/config/colcon.ubuntu.upstream.yaml
+++ b/config/colcon.ubuntu.upstream.yaml
@@ -1,6 +1,6 @@
 name: colcon
 method: https://packagecloud.io/dirk-thomas/colcon/ubuntu
-suites: [focal, jammy, noble]
+suites: [focal, jammy, noble, resolute]
 component: main
 architectures: [i386, amd64, armhf, arm64, source]
 filter_formula: "\


### PR DESCRIPTION
I haven't back-populated the Package Cloud repo with previously released colcon packages yet, but we are getting new packages pushed there.