### PR TITLE
Fix aptly_importer.py for repos without sources

### DIFF
--- a/scripts/aptly/aptly_importer.py
+++ b/scripts/aptly/aptly_importer.py
@@ -166,9 +166,11 @@ class UpdaterConfiguration():
             self.architectures = self.config['architectures']
             # source was accepted as a valid architecture to indicate that
             # source packages need to be download. It is not a valid arch in aptly
-            if 'source' in self.config['architectures']:
-                self.architectures = self.config['architectures'].remove('source')
-            self.architectures = self.config['architectures']
+            if 'source' in self.architectures:
+                self.architectures.remove('source')
+                self.with_sources = True
+            else:
+                self.with_sources = False
             self.component = self.config['component']
             self.filter_formula = self.reprepro2aptly.convert(
                 self.config['filter_formula'])
@@ -218,9 +220,11 @@ class UpdaterManager():
         if self.aptly.exists(Aptly.ArtifactType.MIRROR, mirror_name):
             self.__log_ok('Removing existing mirror')
             self.aptly.run(['mirror', 'drop', mirror_name])
-        create_cmd = ['mirror', 'create', '-with-sources',
+        create_cmd = ['mirror', 'create',
                       f"-architectures={','.join(self.config.architectures)}",
                       f"-filter={self.config.filter_formula}"]
+        if self.config.with_sources:
+            create_cmd += ['-with-sources']
         if self.ignore_mirror_signature:
             create_cmd += ['-ignore-signatures']
         create_cmd += [mirror_name,

--- a/scripts/aptly/aptly_importer.py
+++ b/scripts/aptly/aptly_importer.py
@@ -224,8 +224,6 @@ class UpdaterManager():
                       f"-with-sources={'true' if self.config.with_sources else 'false'}",
                       f"-architectures={','.join(self.config.architectures)}",
                       f"-filter={self.config.filter_formula}"]
-        if self.config.with_sources:
-            create_cmd += ['-with-sources']
         if self.ignore_mirror_signature:
             create_cmd += ['-ignore-signatures']
         create_cmd += [mirror_name,

--- a/scripts/aptly/aptly_importer.py
+++ b/scripts/aptly/aptly_importer.py
@@ -221,6 +221,7 @@ class UpdaterManager():
             self.__log_ok('Removing existing mirror')
             self.aptly.run(['mirror', 'drop', mirror_name])
         create_cmd = ['mirror', 'create',
+                      f"-with-sources={'true' if self.config.with_sources else 'false'}",
                       f"-architectures={','.join(self.config.architectures)}",
                       f"-filter={self.config.filter_formula}"]
         if self.config.with_sources:


### PR DESCRIPTION
It doesn't appear that this script ever worked correctly on repo configurations without sources. This change cleans up the removal of 'sources' from the arch list and records its presence to conditionally pass `-with-sources` to the aptly mirror creation later.

At present, there are three configs that fit this criteria:
- namniart_armhf
- pcl_xenial_armhf_backport
- rticonnextdds730

I'd like to add another one for importing GurumDDS.