### PR TITLE
Add aptly importer config for GurumDDS

### DIFF
--- a/config/gurum.ubuntu.upstream.yaml
+++ b/config/gurum.ubuntu.upstream.yaml
@@ -1,0 +1,8 @@
+name: gurum
+method: https://packages.gurum.cc/ubuntu
+suites: [jammy, noble, resolute]
+component: main
+architectures: [amd64, arm64]
+filter_formula: "\
+(Package (% gurumdds-3.2), $Version (% 3.2.19*))\
+"


### PR DESCRIPTION
Requires #267

Results in these packages:
```shell
$ for i in jammy noble resolute; do aptly mirror search gurum-$i; done
gurumdds-3.2_3.2.19-jammy_amd64
gurumdds-3.2_3.2.19-jammy_arm64
gurumdds-3.2_3.2.19-noble_amd64
gurumdds-3.2_3.2.19-noble_arm64
gurumdds-3.2_3.2.19-resolute_amd64
gurumdds-3.2_3.2.19-resolute_arm64
```