### PR TITLE
Import key for Debian Trixie in CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
             gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys 0146DC6D4A0B2914BDED34DB648ACFD622F3D138 # Debian Buster
             gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys 0E98404D386FA1D9 # Debian Bullseye
             gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys 4CB50190207B4758A3F73A796ED0E7B82643E131 # Debian bookworm
+            gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys B8E5F13176D2A7A75220028078DBA3BC47EF2265 # Debian Trixie
             gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --recv-keys 67170598AF249743 # OSRF Repository
 
       - name: Generate key


### PR DESCRIPTION
Should hopefully resolve this message in the CI for this repository:
```
gpgv: Signature made Mon Jul 27 14:09:40 2026 UTC
gpgv:                using RSA key B8E5F13176D2A7A75220028078DBA3BC47EF2265
gpgv: Can't check signature: No public key
ERROR: unable to fetch mirror: verification of detached signature failed: exit status 2
```