### PR TITLE
Strip quotes from maintainer names in the announcement

### DIFF
--- a/src/reprepro_updater/diff_repos.py
+++ b/src/reprepro_updater/diff_repos.py
@@ -30,13 +30,10 @@ def strip_email(maintainer):
     """Extract the maintainer name from a debian Maintainer field."""
     name = re.sub("(.*)<.*>", "\\1", maintainer).strip()
     # bloom wraps the name in double quotes to keep the field RFC 5322 compliant, see:
-    # https://github.com/ros-infrastructure/bloom/pull/770. Unwrap the name.
-    # Only unwrap a pair of quotes around the whole name: a field holding more than one mailbox also
-    # starts and ends with a quote, and stripping those would corrupt it rather than leave it merely
-    # ugly.
-    unwrapped = re.match('^"([^"]*)"$', name)
-    if unwrapped:
-        name = unwrapped.group(1)
+    # https://github.com/ros-infrastructure/bloom/pull/770. Unwrap the name, which is simply the
+    # inverse of that: bloom adds one quote at each end and does not escape any quote in the name.
+    if name.startswith('"') and name.endswith('"'):
+        name = name[1:-1]
     return name
 
 

--- a/src/reprepro_updater/diff_repos.py
+++ b/src/reprepro_updater/diff_repos.py
@@ -27,7 +27,17 @@ def convert_tuples_list_to_dict(tuples_list):
 
 
 def strip_email(maintainer):
-    return re.sub("(.*)<.*>", "\\1", maintainer)
+    """Extract the maintainer name from a debian Maintainer field."""
+    name = re.sub("(.*)<.*>", "\\1", maintainer).strip()
+    # bloom wraps the name in double quotes to keep the field RFC 5322 compliant, see:
+    # https://github.com/ros-infrastructure/bloom/pull/770. Unwrap the name.
+    # Only unwrap a pair of quotes around the whole name: a field holding more than one mailbox also
+    # starts and ends with a quote, and stripping those would corrupt it rather than leave it merely
+    # ugly.
+    unwrapped = re.match('^"([^"]*)"$', name)
+    if unwrapped:
+        name = unwrapped.group(1)
+    return name
 
 
 def core_version(version):
@@ -109,7 +119,7 @@ def compute_annoucement(rosdistro, pf_old, pf_new):
 
     maintainers = set()
     for p in added_packages | updated_packages:
-        maintainers.add(strip_email(new_packages[p]['Maintainer']).strip())
+        maintainers.add(strip_email(new_packages[p]['Maintainer']))
 
     out = ''
 

--- a/test/test_data/Packages.maintainers.target
+++ b/test/test_data/Packages.maintainers.target
@@ -1,0 +1,28 @@
+Package: ros-humble-updated-pkg
+Source: updated-pkg
+Priority: optional
+Section: misc
+Installed-Size: 25
+Maintainer: Bugs Bunny <bugs.bunny@openrobotics.org>
+Architecture: amd64
+Version: 1.0.0-1jammy.20260401.120000
+Depends: libc6
+Filename: pool/main/r/ros-humble-updated-pkg/ros-humble-updated-pkg_1.0.0-1jammy.20260401.120000_amd64.deb
+Size: 5108
+SHA256: 0f5f2e1f0e4b8b3a1c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b
+Homepage: https://index.ros.org/p/updated_pkg/#humble
+Description: A package that gets updated by the sync
+
+Package: ros-humble-removed-pkg
+Source: removed-pkg
+Priority: optional
+Section: misc
+Installed-Size: 12
+Maintainer: Elmer Fudd <elmer.fudd@acme.com>
+Architecture: amd64
+Version: 0.5.0-1jammy.20260401.120000
+Depends: libc6
+Filename: pool/main/r/ros-humble-removed-pkg/ros-humble-removed-pkg_0.5.0-1jammy.20260401.120000_amd64.deb
+Size: 3204
+SHA256: 1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f809
+Description: A package that is no longer in the upstream repo

--- a/test/test_data/Packages.maintainers.upstream
+++ b/test/test_data/Packages.maintainers.upstream
@@ -1,0 +1,70 @@
+Package: ros-humble-updated-pkg
+Source: updated-pkg
+Priority: optional
+Section: misc
+Installed-Size: 26
+Maintainer: "Bugs Bunny" <bugs.bunny@openrobotics.org>
+Architecture: amd64
+Version: 2.0.0-1jammy.20260801.120000
+Depends: libc6
+Filename: pool/main/r/ros-humble-updated-pkg/ros-humble-updated-pkg_2.0.0-1jammy.20260801.120000_amd64.deb
+Size: 5210
+SHA256: 0f5f2e1f0e4b8b3a1c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b
+Homepage: https://index.ros.org/p/updated_pkg/#humble
+Description: A package that gets updated by the sync
+
+Package: ros-humble-added-quoted-pkg
+Source: added-quoted-pkg
+Priority: optional
+Section: misc
+Installed-Size: 18
+Maintainer: "Pepé Le Pew" <pepe.le.pew@openrobotics.org>
+Architecture: amd64
+Version: 1.0.0-1jammy.20260801.120000
+Depends: libc6
+Filename: pool/main/r/ros-humble-added-quoted-pkg/ros-humble-added-quoted-pkg_1.0.0-1jammy.20260801.120000_amd64.deb
+Size: 4102
+SHA256: 2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a
+Description: An added package whose maintainer name is quoted and non-ASCII
+
+Package: ros-humble-added-unquoted-pkg
+Source: added-unquoted-pkg
+Priority: optional
+Section: misc
+Installed-Size: 18
+Maintainer: Bugs Bunny <bugs.bunny@openrobotics.org>
+Architecture: amd64
+Version: 1.0.0-1jammy.20260801.120000
+Depends: libc6
+Filename: pool/main/r/ros-humble-added-unquoted-pkg/ros-humble-added-unquoted-pkg_1.0.0-1jammy.20260801.120000_amd64.deb
+Size: 4110
+SHA256: 3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b
+Description: An added package released with a bloom that does not quote the name
+
+Package: ros-humble-added-quoted-comma-pkg
+Source: added-quoted-comma-pkg
+Priority: optional
+Section: misc
+Installed-Size: 18
+Maintainer: "Daffy Duck, Porky Pig" <daffy.duck@acme.com>
+Architecture: amd64
+Version: 1.0.0-1jammy.20260801.120000
+Depends: libc6
+Filename: pool/main/r/ros-humble-added-quoted-comma-pkg/ros-humble-added-quoted-comma-pkg_1.0.0-1jammy.20260801.120000_amd64.deb
+Size: 4118
+SHA256: 4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c
+Description: An added package whose quoted maintainer name contains a comma
+
+Package: ros-humble-added-unquoted-comma-pkg
+Source: added-unquoted-comma-pkg
+Priority: optional
+Section: misc
+Installed-Size: 18
+Maintainer: Acme, Inc. <opensource@acme.com>
+Architecture: amd64
+Version: 1.0.0-1jammy.20260801.120000
+Depends: libc6
+Filename: pool/main/r/ros-humble-added-unquoted-comma-pkg/ros-humble-added-unquoted-comma-pkg_1.0.0-1jammy.20260801.120000_amd64.deb
+Size: 4126
+SHA256: 5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d
+Description: An added package whose unquoted maintainer name contains a comma

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -26,3 +26,71 @@ def test_announcement():
     assert 'Removed Packages [10]:' in announcement
     assert 'Updated Packages [1740]:' in announcement
     assert 'Added Packages [214]:' in announcement
+
+
+def get_test_packagefile(name):
+    url = 'file://' + os.path.abspath(os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        'test_data', name))
+    return diff_repos.get_packagefile_from_url(url)
+
+
+def test_strip_email():
+    # bloom quotes the maintainer name since 0.14.3, but packages released
+    # with an older bloom are still around, so both forms must be handled
+    assert 'Bugs Bunny' == diff_repos.strip_email(
+        'Bugs Bunny <bugs.bunny@openrobotics.org>')
+    assert 'Bugs Bunny' == diff_repos.strip_email(
+        '"Bugs Bunny" <bugs.bunny@openrobotics.org>')
+    # names are not restricted to ASCII
+    assert u'Pepé Le Pew' == diff_repos.strip_email(
+        u'"Pepé Le Pew" <pepe.le.pew@openrobotics.org>')
+    # a name may contain a comma, quoted or not
+    assert 'Daffy Duck, Porky Pig' == diff_repos.strip_email(
+        '"Daffy Duck, Porky Pig" <daffy.duck@acme.com>')
+    assert 'Acme, Inc.' == diff_repos.strip_email(
+        'Acme, Inc. <opensource@acme.com>')
+    # a parenthesized comment is part of the name, it is not an address
+    assert 'Wile E. Coyote (Super Genius)' == diff_repos.strip_email(
+        'Wile E. Coyote (Super Genius) <wile.e.coyote@acme.com>')
+    # the address is optional
+    assert 'Acme Robotics' == diff_repos.strip_email('Acme Robotics')
+    assert 'Acme Robotics' == diff_repos.strip_email('"Acme Robotics"')
+    # a lone double quote is not a quoted name
+    assert '"' == diff_repos.strip_email('"')
+    # a name and an address that each hold several comma-separated values are
+    # still a single entry, they are not split apart
+    assert 'Yosemite Sam, Foghorn Leghorn' == diff_repos.strip_email(
+        'Yosemite Sam, Foghorn Leghorn '
+        '<yosemite.sam@openrobotics.org, foghorn.leghorn@acme.com>')
+    assert 'Yosemite Sam, Foghorn Leghorn' == diff_repos.strip_email(
+        '"Yosemite Sam, Foghorn Leghorn" '
+        '<yosemite.sam@openrobotics.org, foghorn.leghorn@acme.com>')
+    # a field holding several mailboxes also starts and ends with a quote, but
+    # those quotes do not wrap a single name, so it is left untouched
+    assert '"Tweety Bird" <tweety@openrobotics.org>, "Sylvester Cat"' == \
+        diff_repos.strip_email(
+            '"Tweety Bird" <tweety@openrobotics.org>, '
+            '"Sylvester Cat" <sylvester@acme.com>')
+
+
+def test_announcement_maintainer_names():
+    pf_old = get_test_packagefile('Packages.maintainers.target')
+    pf_new = get_test_packagefile('Packages.maintainers.upstream')
+
+    announcement = diff_repos.compute_annoucement('humble', pf_old, pf_new)
+    maintainers = announcement.split('following maintainers: \n\n')[1]
+
+    # maintainer names are reported without the quotes bloom adds to them
+    assert '"' not in maintainers
+    assert ' * Bugs Bunny\n' in maintainers
+    assert u' * Pepé Le Pew\n' in maintainers
+    assert ' * Daffy Duck, Porky Pig\n' in maintainers
+    assert ' * Acme, Inc.\n' in maintainers
+    # a maintainer who released one package with a bloom that quotes the name
+    # and another with a bloom that does not is only listed once
+    assert 1 == maintainers.count(' * Bugs Bunny\n')
+    assert 4 == len(maintainers.strip().splitlines())
+
+    # the maintainer of a removed package is not credited
+    assert 'Elmer Fudd' not in maintainers

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -56,8 +56,10 @@ def test_strip_email():
     # the address is optional
     assert 'Acme Robotics' == diff_repos.strip_email('Acme Robotics')
     assert 'Acme Robotics' == diff_repos.strip_email('"Acme Robotics"')
-    # a lone double quote is not a quoted name
-    assert '"' == diff_repos.strip_email('"')
+    # bloom does not escape a quote inside the name, so only the pair it added
+    # around the whole name is removed
+    assert 'Wile E. "Super Genius" Coyote' == diff_repos.strip_email(
+        '"Wile E. "Super Genius" Coyote" <wile.e.coyote@acme.com>')
     # a name and an address that each hold several comma-separated values are
     # still a single entry, they are not split apart
     assert 'Yosemite Sam, Foghorn Leghorn' == diff_repos.strip_email(
@@ -66,12 +68,6 @@ def test_strip_email():
     assert 'Yosemite Sam, Foghorn Leghorn' == diff_repos.strip_email(
         '"Yosemite Sam, Foghorn Leghorn" '
         '<yosemite.sam@openrobotics.org, foghorn.leghorn@acme.com>')
-    # a field holding several mailboxes also starts and ends with a quote, but
-    # those quotes do not wrap a single name, so it is left untouched
-    assert '"Tweety Bird" <tweety@openrobotics.org>, "Sylvester Cat"' == \
-        diff_repos.strip_email(
-            '"Tweety Bird" <tweety@openrobotics.org>, '
-            '"Sylvester Cat" <sylvester@acme.com>')
 
 
 def test_announcement_maintainer_names():


### PR DESCRIPTION
Fixes #271

bloom quotes the name in debian/control since 0.14.3: https://github.com/ros-infrastructure/bloom/pull/770. This looks weird and also results in a maintainer being listed twice when they released packages with both an older and a newer bloom.

I added tests to cover this, which include corner cases we don't really encounter much, including `Maintainer:` entries with multiple comma-separated names (because you can just define separate `<maintainer/>`). However, it could happen, or the maintainer name might be the name of a company and include a comma.

I kept these tests to document the behaviour in that case.

This targets the `refactor` branch, because that's what all `*rel_sync-packages-to-main` jobs seem to use, not `master`.

---

I used AI (Claude Opus 5) to find this issue and make the initial fix, which I then reviewed and re-worked.